### PR TITLE
Fixing Cr0 & Cr4 Bits During VMX Operation 

### DIFF
--- a/hyperdbg/hprdbghv/Common.h
+++ b/hyperdbg/hprdbghv/Common.h
@@ -348,6 +348,61 @@ typedef struct _CONTROL_REGISTER_4
     };
 } CONTROL_REGISTER_4, *PCONTROL_REGISTER_4;
 
+typedef union
+{
+    unsigned __int64 Flags;
+
+    struct
+    {
+        unsigned __int64 ProtectionEnable : 1;
+
+        unsigned __int64 MonitorCoprocessor : 1;
+
+        unsigned __int64 EmulateFpu : 1;
+
+        unsigned __int64 TaskSwitched : 1;
+
+        unsigned __int64 ExtensionType : 1;
+
+        unsigned __int64 NumericError : 1;
+
+        unsigned __int64 Reserved1 : 10;
+
+        unsigned __int64 WriteProtect : 1;
+
+        unsigned __int64 Reserved2 : 1;
+
+        unsigned __int64 AlignmentMask : 1;
+
+        unsigned __int64 Reserved3 : 10;
+
+        unsigned __int64 NotWriteThrough : 1;
+
+        unsigned __int64 CacheDisable : 1;
+
+        unsigned __int64 PagingEnable : 1;
+
+        unsigned __int64 Reserved4 : 32;
+    };
+
+} CONTROL_REGISTER_0;
+
+typedef union CR_FIXED
+{
+    struct
+    {
+        unsigned long Low;
+        long          High;
+    } Split;
+    struct
+    {
+        unsigned long Low;
+        long          High;
+    } u;
+    __int64 Flags;
+}CR_FIXED, *PCR_FIXED;
+
+
 /**
  * @brief Debug Register 7 Structure
  * 

--- a/hyperdbg/hprdbghv/Common.h
+++ b/hyperdbg/hprdbghv/Common.h
@@ -385,7 +385,7 @@ typedef union
         unsigned __int64 Reserved4 : 32;
     };
 
-} CONTROL_REGISTER_0;
+} CONTROL_REGISTER_0, *PCONTROL_REGISTER_0;
 
 typedef union CR_FIXED
 {

--- a/hyperdbg/hprdbghv/Vmx.c
+++ b/hyperdbg/hprdbghv/Vmx.c
@@ -131,8 +131,6 @@ FixCr4AndCr0Bits()
     Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED1);
     Cr4.Flags &= Cr_Fixed.Split.Low;
     __writecr4(Cr4.Flags);
-    Cr4.VmxEnable = 0;
-    __writecr4(Cr4.Flags);
 }    
 
 /**

--- a/hyperdbg/hprdbghv/Vmx.c
+++ b/hyperdbg/hprdbghv/Vmx.c
@@ -107,7 +107,7 @@ VmxInitializer()
 
 /**
  * @Fixes The Cr4 And Cr0 Bits During VMX Operation Preventing Them From Any Change 
- * ref: https://revers.engineering/day-2-entering-vmx-operation/
+ * @ref https://revers.engineering/day-2-entering-vmx-operation/
  * @param void
  * @return void
  */

--- a/hyperdbg/hprdbghv/Vmx.c
+++ b/hyperdbg/hprdbghv/Vmx.c
@@ -106,6 +106,36 @@ VmxInitializer()
 }
 
 /**
+ * @Fixes The Cr4 And Cr0 Bits During VMX Operation Preventing Them From Any Change 
+ * ref: https://revers.engineering/day-2-entering-vmx-operation/
+ * @param void
+ * @return void
+ */
+
+VOID
+FixCr4AndCr0Bits()
+{
+    CR_FIXED Cr_Fixed           = {0};
+    CONTROL_REGISTER_4 Cr4      = {0};
+    CONTROL_REGISTER_0 Cr0      = {0};
+
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED0);
+    Cr0.Flags = __readcr0();
+    Cr0.Flags |= Cr_Fixed.Split.Low;
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED1);
+    Cr0.Flags &= Cr_Fixed.Split.Low;
+    __writecr0(Cr0.Flags);
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED0);
+    Cr4.Flags = __readcr4();
+    Cr4.Flags |= Cr_Fixed.Split.Low;
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED1);
+    Cr4.Flags &= Cr_Fixed.Split.Low;
+    __writecr4(Cr4.Flags);
+    Cr4.VmxEnable = 0;
+    __writecr4(Cr4.Flags);
+}    
+
+/**
  * @brief It can deteministcly check whether the caller is on vmx-root mode
  * or not
  * 

--- a/hyperdbg/hprdbghv/Vmx.c
+++ b/hyperdbg/hprdbghv/Vmx.c
@@ -119,12 +119,17 @@ FixCr4AndCr0Bits()
     CONTROL_REGISTER_4 Cr4      = {0};
     CONTROL_REGISTER_0 Cr0      = {0};
 
+    // Fix Cr0 
+    
     Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED0);
     Cr0.Flags = __readcr0();
     Cr0.Flags |= Cr_Fixed.Split.Low;
     Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED1);
     Cr0.Flags &= Cr_Fixed.Split.Low;
     __writecr0(Cr0.Flags);
+    
+    // Fix Cr4 
+    
     Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED0);
     Cr4.Flags = __readcr4();
     Cr4.Flags |= Cr_Fixed.Split.Low;

--- a/hyperdbg/hprdbghv/Vmx.h
+++ b/hyperdbg/hprdbghv/Vmx.h
@@ -695,5 +695,8 @@ VmxCheckIsOnVmxRoot();
 BOOLEAN
 VmxVirtualizeCurrentSystem(PVOID GuestStack);
 
+VOID
+FixCr4AndCr0Bits();
+
 BOOLEAN
 VmxSetupVmcs(VIRTUAL_MACHINE_STATE * CurrentGuestState, PVOID GuestStack);

--- a/hyperdbg/hprdbghv/VmxRegions.c
+++ b/hyperdbg/hprdbghv/VmxRegions.c
@@ -33,6 +33,10 @@ VmxDpcBroadcastAllocateVmxonRegions(KDPC * Dpc, PVOID DeferredContext, PVOID Sys
     AsmEnableVmxOperation();
 
     LogDebugInfo("VMX-Operation Enabled Successfully");
+    
+    // Fix Cr4 and Cr0 bits during vmx operation 
+    
+    FixCr4AndCr0Bits();
 
     if (!VmxAllocateVmxonRegion(&g_GuestState[CurrentProcessorNumber]))
     {

--- a/hyperdbg/hprdbghv/VmxRegions.c
+++ b/hyperdbg/hprdbghv/VmxRegions.c
@@ -286,21 +286,21 @@ FixCr4AndCr0Bits()
     CONTROL_REGISTER_4 Cr4      = {0};
     CONTROL_REGISTER_0 Cr0      = {0};
 
-    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR0_FIXED0);
-    Cr0.Flags    = __readcr0();
-    Cr0.Flags |= Cr_Fixed.Split.Low;
-    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR0_FIXED1);
-    Cr0.Flags &= Cr_Fixed.Split.Low;
-    __writecr0(Cr0.Flags);
-    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR4_FIXED0);
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED0);
+    Cr0.flags = __readcr0();
+    Cr0.flags |= Cr_Fixed.Split.Low;
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED1);
+    Cr0.flags &= Cr_Fixed.Split.Low;
+    __writecr0(Cr0.flags);
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED0);
     Cr4.Flags = __readcr4();
     Cr4.Flags |= Cr_Fixed.Split.Low;
-    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR4_FIXED1);
+    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED1);
     Cr4.Flags &= Cr_Fixed.Split.Low;
     __writecr4(Cr4.Flags);
     Cr4.VmxEnable = 0;
     __writecr4(Cr4.Flags);
-}     
+}    
 
 /**
  * @brief Allocate a buffer forr I/O Bitmap

--- a/hyperdbg/hprdbghv/VmxRegions.c
+++ b/hyperdbg/hprdbghv/VmxRegions.c
@@ -270,37 +270,7 @@ VmxAllocateMsrBitmap(INT ProcessorID)
     LogDebugInfo("Msr Bitmap Physical Address : 0x%llx", g_GuestState[ProcessorID].MsrBitmapPhysicalAddress);
 
     return TRUE;
-}
-
-/**
- * @Fixes The Cr4 And Cr0 Bits During VMX Operation Preventing Them From Any Change 
- * ref: https://revers.engineering/day-2-entering-vmx-operation/
- * @param void
- * @return void
- */
-
-VOID
-FixCr4AndCr0Bits()
-{
-    CR_FIXED Cr_Fixed           = {0};
-    CONTROL_REGISTER_4 Cr4      = {0};
-    CONTROL_REGISTER_0 Cr0      = {0};
-
-    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED0);
-    Cr0.Flags = __readcr0();
-    Cr0.Flags |= Cr_Fixed.Split.Low;
-    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED1);
-    Cr0.Flags &= Cr_Fixed.Split.Low;
-    __writecr0(Cr0.Flags);
-    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED0);
-    Cr4.Flags = __readcr4();
-    Cr4.Flags |= Cr_Fixed.Split.Low;
-    Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED1);
-    Cr4.Flags &= Cr_Fixed.Split.Low;
-    __writecr4(Cr4.Flags);
-    Cr4.VmxEnable = 0;
-    __writecr4(Cr4.Flags);
-}     
+} 
 
 /**
  * @brief Allocate a buffer forr I/O Bitmap

--- a/hyperdbg/hprdbghv/VmxRegions.c
+++ b/hyperdbg/hprdbghv/VmxRegions.c
@@ -269,6 +269,36 @@ VmxAllocateMsrBitmap(INT ProcessorID)
 }
 
 /**
+ * @Fixes The Cr4 And Cr0 Bits During VMX Operation Preventing Them From Any Change 
+ * ref: https://revers.engineering/day-2-entering-vmx-operation/
+ * @param void
+ * @return void
+ */
+
+VOID
+FixCr4AndCr0Bits()
+{
+    CR_FIXED Cr_Fixed           = {0};
+    CONTROL_REGISTER_4 Cr4      = {0};
+    CONTROL_REGISTER_0 Cr0      = {0};
+
+    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR0_FIXED0);
+    Cr0.Flags    = __readcr0();
+    Cr0.Flags |= Cr_Fixed.Split.Low;
+    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR0_FIXED1);
+    Cr0.Flags &= Cr_Fixed.Split.Low;
+    __writecr0(Cr0.Flags);
+    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR4_FIXED0);
+    Cr4.Flags = __readcr4();
+    Cr4.Flags |= Cr_Fixed.Split.Low;
+    Cr_Fixed.All = __readmsr(MSR_IA32_VMX_CR4_FIXED1);
+    Cr4.Flags &= Cr_Fixed.Split.Low;
+    __writecr4(Cr4.Flags);
+    Cr4.VmxEnable = 0;
+    __writecr4(Cr4.Flags);
+}     
+
+/**
  * @brief Allocate a buffer forr I/O Bitmap
  * 
  * @param ProcessorID 

--- a/hyperdbg/hprdbghv/VmxRegions.c
+++ b/hyperdbg/hprdbghv/VmxRegions.c
@@ -287,11 +287,11 @@ FixCr4AndCr0Bits()
     CONTROL_REGISTER_0 Cr0      = {0};
 
     Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED0);
-    Cr0.flags = __readcr0();
-    Cr0.flags |= Cr_Fixed.Split.Low;
+    Cr0.Flags = __readcr0();
+    Cr0.Flags |= Cr_Fixed.Split.Low;
     Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR0_FIXED1);
-    Cr0.flags &= Cr_Fixed.Split.Low;
-    __writecr0(Cr0.flags);
+    Cr0.Flags &= Cr_Fixed.Split.Low;
+    __writecr0(Cr0.Flags);
     Cr_Fixed.Flags = __readmsr(MSR_IA32_VMX_CR4_FIXED0);
     Cr4.Flags = __readcr4();
     Cr4.Flags |= Cr_Fixed.Split.Low;
@@ -300,7 +300,7 @@ FixCr4AndCr0Bits()
     __writecr4(Cr4.Flags);
     Cr4.VmxEnable = 0;
     __writecr4(Cr4.Flags);
-}    
+}     
 
 /**
  * @brief Allocate a buffer forr I/O Bitmap


### PR DESCRIPTION
Hello All, I Added a Method To The Code To Insure That CR0 and CR4 Registers Not Be Changed During The VMX Operation The IDEA Is Derived From The Intel Manual Here:

![img](https://user-images.githubusercontent.com/68482847/109338469-fcec1c80-786e-11eb-93bc-eeb41065a33c.PNG) 

The Code Is From https://revers.engineering/day-2-entering-vmx-operation/ However I made Some Changes To It So I Can Follow The Project Coding Style: