### PR TITLE
fix EptHookWriteAbsoluteJump Effect on register

### DIFF
--- a/hyperdbg/hprdbgctrl/hprdbgctrl.cpp
+++ b/hyperdbg/hprdbgctrl/hprdbgctrl.cpp
@@ -157,7 +157,7 @@ ReadIrpBasedBuffer()
             ShowMessages("err, CreateFile failed with (0x%x)\n", ErrorNum);
         }
 
-        g_DeviceHandle = NULL;
+        Handle = NULL;
         return;
     }
 
@@ -403,6 +403,15 @@ ReadIrpBasedBuffer()
                 // the thread should not work anymore
                 //
                 free(OutputBuffer);
+
+                //
+                // closeHandle
+                //
+                if (!CloseHandle(Handle))
+                {
+                    ShowMessages("err, closing handle 0x%x\n", GetLastError());
+                };
+
                 return;
             }
         }
@@ -412,6 +421,14 @@ ReadIrpBasedBuffer()
         ShowMessages(" Exception !\n");
     }
     free(OutputBuffer);
+
+    //
+    // closeHandle
+    //
+    if (!CloseHandle(Handle))
+    {
+        ShowMessages("err, closing handle 0x%x\n", GetLastError());
+    };
 }
 
 /**


### PR DESCRIPTION
我发现一个问题。
I found a problem. The epthookwriteabsolutejump function will affect the value of R11。
for example NtCreateFile in Win7
![image](https://user-images.githubusercontent.com/10446984/128485181-c5120cd2-627a-493a-907e-65add76531c1.png)

Fix it
use
```
push Lower 4-byte TargetAddress
mov dword ptr ss:[rsp + 4],High 4-byte TargetAddress
ret
```
instead
```
mov r11, Target
push r11
ret
```