### PR TITLE
Fix llvm compile problem

### DIFF
--- a/hyperdbg/hprdbghv/code/debugger/features/hooks/ept-hook/EptHook.c
+++ b/hyperdbg/hprdbghv/code/debugger/features/hooks/ept-hook/EptHook.c
@@ -475,7 +475,7 @@ EptHookRestoreAllHooksToOrginalEntry()
     //
     if (!g_GuestState[KeGetCurrentProcessorNumber()].IsOnVmxRootMode)
     {
-        return FALSE;
+        return;
     }
 
     TempList = &g_EptState->HookedPagesList;

--- a/hyperdbg/hprdbghv/code/vmm/ept/Vpid.c
+++ b/hyperdbg/hprdbghv/code/vmm/ept/Vpid.c
@@ -26,7 +26,7 @@ Invvpid(INVVPID_ENUM Type, INVVPID_DESCRIPTOR * Descriptor)
         Descriptor                               = &ZeroDescriptor;
     }
 
-    return AsmInvvpid(Type, Descriptor);
+    AsmInvvpid(Type, Descriptor);
 }
 
 /**


### PR DESCRIPTION
Fix llvm compile problem
```C++
VOID
EptHookRestoreAllHooksToOrginalEntry()
{
    PLIST_ENTRY TempList = 0;

    //
    // Should be called from vmx-root, for calling from vmx non-root use the corresponding VMCALL
    //
    if (!g_GuestState[KeGetCurrentProcessorNumber()].IsOnVmxRootMode)
    {
        return;
    }
```

```C++
void
Invvpid(INVVPID_ENUM Type, INVVPID_DESCRIPTOR * Descriptor)
{
    if (!Descriptor)
    {
        static INVVPID_DESCRIPTOR ZeroDescriptor = {0};
        Descriptor                               = &ZeroDescriptor;
    }

    AsmInvvpid(Type, Descriptor);
}
```
