### PR TITLE
Fix incorrect type in function 'HvResumeToNextInstruction'.

### DIFF
--- a/hyperdbg/hprdbghv/code/vmm/vmx/Hv.c
+++ b/hyperdbg/hprdbghv/code/vmm/vmx/Hv.c
@@ -313,7 +313,7 @@ HvResumeToNextInstruction()
 {
     ULONG64 ResumeRIP             = NULL;
     ULONG64 CurrentRIP            = NULL;
-    ULONG   ExitInstructionLength = 0;
+    size_t  ExitInstructionLength = 0;
 
     __vmx_vmread(GUEST_RIP, &CurrentRIP);
     __vmx_vmread(VM_EXIT_INSTRUCTION_LEN, &ExitInstructionLength);


### PR DESCRIPTION
The instrinsic type of '__vmx_vmread ' is 
```C++
unsigned char __vmx_vmread(
   size_t Field,
   size_t *FieldValue
);
```
So we should use size_t instead of ULONG.

https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/intrinsics/vmx-vmread.md