### PR TITLE
Fix incorrect type: __vmx_on

### DIFF
--- a/hyperdbg/hprdbghv/code/vmm/vmx/Vmx.c
+++ b/hyperdbg/hprdbghv/code/vmm/vmx/Vmx.c
@@ -499,7 +499,7 @@ VmxVmptrst()
 BOOLEAN
 VmxClearVmcsState(VIRTUAL_MACHINE_STATE * CurrentGuestState)
 {
-    int VmclearStatus;
+    UINT8 VmclearStatus;
 
     //
     // Clear the state of the VMCS to inactive

--- a/hyperdbg/hprdbghv/code/vmm/vmx/VmxRegions.c
+++ b/hyperdbg/hprdbghv/code/vmm/vmx/VmxRegions.c
@@ -23,7 +23,7 @@ VmxAllocateVmxonRegion(_Inout_ VIRTUAL_MACHINE_STATE * CurrentGuestState)
 {
     IA32_VMX_BASIC_MSR VmxBasicMsr = {0};
     SIZE_T             VmxonSize;
-    int                VmxonStatus;
+    UINT8              VmxonStatus;
     UINT8 *            VmxonRegion;
     UINT64             VmxonRegionPhysicalAddr;
     UINT64             AlignedVmxonRegion;


### PR DESCRIPTION
The instrinsic type of '__vmx_on' is
```C++
unsigned char __vmx_on(
   unsigned __int64 *VmsSupportPhysicalAddress
);
```
https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/intrinsics/vmx-on.md