### PR TITLE
Include <intrin.h> to recognize insrinsic type.

### DIFF
--- a/hyperdbg/hprdbghv/pch.h
+++ b/hyperdbg/hprdbghv/pch.h
@@ -24,6 +24,7 @@
 #include <wdm.h>
 #include <ntstrsafe.h>
 #include <Windef.h>
+#include <intrin.h>
 
 //
 // Scope definitions


### PR DESCRIPTION
Include <intrin.h> to recognize insrinsic type.