### PR TITLE
Fix #142

### DIFF
--- a/hyperdbg/hprdbghv/code/debugger/features/hooks/ept-hook/EptHook.c
+++ b/hyperdbg/hprdbghv/code/debugger/features/hooks/ept-hook/EptHook.c
@@ -1012,11 +1012,11 @@ EptHook2(PVOID TargetAddress, PVOID HookFunction, UINT32 ProcessId, BOOLEAN SetH
         return FALSE;
     }
 
-    if (SetHookForWrite && !SetHookForRead)
+    if (!SetHookForWrite && SetHookForRead)
     {
         //
         // The hidden hook with Write Enable and Read Disabled will cause EPT violation!
-        //
+        // fixed 
         return FALSE;
     }
 


### PR DESCRIPTION
# Description

Fixes #142: Write access to 1 and Read access to 0 cause EPT misconfiguration! 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

