### PR TITLE
Adding comments to function 'MemoryManagerReadProcessMemoryNormal'.

### DIFF
--- a/hyperdbg/hprdbghv/code/memory/MemoryManager.c
+++ b/hyperdbg/hprdbghv/code/memory/MemoryManager.c
@@ -19,7 +19,7 @@
  * @param PID Target Process Id
  * @param Address Target Address
  * @param MemType Type of memory
- * @param UserBuffer Buffer to save to the user
+ * @param UserBuffer Buffer to save to the user. This buffer must be in nonpageable memory.
  * @param Size Size of read
  * @param ReturnSize Return Size
  * @return NTSTATUS 


### PR DESCRIPTION
Adding comments to function 'MemoryManagerReadProcessMemoryNormal'.
https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/nf-ntddk-mmcopymemory

