### PR TITLE
Fixed msr read using the wrong constant value

### DIFF
--- a/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
@@ -80,7 +80,7 @@ EptBuildMtrrMap()
         // For each dynamic register pair
         //
         CurrentPhysBase.Flags = __readmsr(IA32_MTRR_PHYSBASE0 + (CurrentRegister * 2));
-        CurrentPhysMask.Flags = __readmsr(IA32_MTRR_PHYSBASE0 + (CurrentRegister * 2));
+        CurrentPhysMask.Flags = __readmsr(IA32_MTRR_PHYSMASK0 + (CurrentRegister * 2));
 
         //
         // Is the range enabled?


### PR DESCRIPTION
# Description

Using wrong constant.

Fixes # (issue)

## Type of change

Switched to appropriate constant.  Machine now works on latest version of Hyperdbg.

- [x] Bug fix (non-breaking change which fixes an issue)
