### PR TITLE
fix bugs for interpreting non-nt modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0.0] - 2022-xx-xx
+## [0.3.0.0] - 2023-XX-XX
+The third (3rd) of the HyperDbg Debugger.
+
+### Added
+- **!crwrite** - Control Register Modification Event ([link](https://docs.hyperdbg.org/commands/extension-commands/crwrite))
+- New pseudo-registers (**$event_tag**, **$event_id**) in the script engine ([link](https://docs.hyperdbg.org/commands/scripting-language/assumptions-and-evaluations#pseudo-registers))
+
+## [0.2.0.0] - 2023-05-03
 The second (2nd) of the HyperDbg Debugger.
 
 ### Added
-- HyperDbg Software Development Kit (DK) is now available 
+- HyperDbg Software Development Kit (SDK) is now available 
 - **flush()** function in script engine ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/events/flush))
 - **memcpy()** function in script engine ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/memory/memcpy))
-- **!crwrite** - Control Register Modification Event ([link](https://docs.hyperdbg.org/commands/extension-commands/crwrite))
 
 ### Changed
+- Global code refactor and fixing bugs!
 - Compiling HyperDbg by using the latest Windows 11 WDK
 - **enable_event** function name changed to **event_enable** ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/events/event_enable))
 - **disable_event** function name changed to **event_disable** ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/events/event_disable))
-- New pseudo-registers (**$event_tag**, **$event_id**) in the script engine ([link](https://docs.hyperdbg.org/commands/scripting-language/assumptions-and-evaluations#pseudo-registers))
 - The "**settings**" command now preserves the configurations in the config file
 - The communication buffer is now separated from the hyperlogger buffer chunks and the buffer size is increased X10 times ([link](https://docs.hyperdbg.org/tips-and-tricks/misc/increase-communication-buffer-size)) 
 - Zydis submodule is updated to version 4 ([link](https://github.com/zyantific/zydis/releases/tag/v4.0.0)) 
@@ -27,7 +33,7 @@ The second (2nd) of the HyperDbg Debugger.
 - **disable_event** script engine function
 
 ## [0.1.0.0] - 2022-05-31
-This is the fist (1st) release of HyperDbg Debugger.
+This is the first (1st) release of HyperDbg Debugger.
 
 ### Added
 - \# (comment in batch scripts)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please visit **[Build & Install](https://docs.hyperdbg.org/getting-started/build
 
 In case you use one of **HyperDbg**'s components in your work, please consider citing our paper.
 
-**1. [HyperDbg: Reinventing Hardware-Assisted Debugging](https://dl.acm.org/doi/abs/10.1145/3548606.3560649)** [[arXiv](https://arxiv.org/abs/2207.05676)]
+**1. [HyperDbg: Reinventing Hardware-Assisted Debugging (CCS'22)](https://dl.acm.org/doi/abs/10.1145/3548606.3560649)** [[arXiv](https://arxiv.org/abs/2207.05676)]
 
 ```
 @inproceedings{karvandi2022hyperdbg,
@@ -50,7 +50,7 @@ In case you use one of **HyperDbg**'s components in your work, please consider c
 }
 ```
 
-You can also read [this article](https://research.hyperdbg.org/debugger/kernel-debugger-design.html) as it describes the overall architecture, technical difficulties, design decisions, and internals of HyperDbg Debugger, and [this article](https://research.hyperdbg.org/debugger/transparency.html) about our efforts on vm-exit transparency. More articles, posts, and resources are available at the **[awesome](https://github.com/HyperDbg/awesome)** repo.
+You can also read [this article](https://research.hyperdbg.org/debugger/kernel-debugger-design.html) as it describes the overall architecture, technical difficulties, design decisions, and internals of HyperDbg Debugger, [this article](https://research.hyperdbg.org/debugger/transparency.html) about our efforts on vm-exit transparency, and [this article](https://research.hyperdbg.org/debugger/chasing-bugs.html) about chasing bugs within hypervisors. More articles, posts, and resources are available at the **[awesome](https://github.com/HyperDbg/awesome)** repo, and in addition, the **[slides](https://github.com/HyperDbg/slides)** repo provides presentation slides for further reference.
 
 ## Unique Features
 ### First Release (v0.1.0.0)
@@ -86,7 +86,7 @@ You can also read [this article](https://research.hyperdbg.org/debugger/kernel-d
 * Various Custom Scripts [<a href="https://github.com/HyperDbg/scripts" target="_blank">link</a>]
 
 ### Second Release (v0.2.0.0)
-(not released yet !)
+* HyperDbg Software Development Kit (SDK) [<a href="https://docs.hyperdbg.org/using-hyperdbg/sdk" target="_blank">link</a>]
 
 ## How does it work?
 

--- a/hyperdbg/symbol-parser/code/symbol-parser.cpp
+++ b/hyperdbg/symbol-parser/code/symbol-parser.cpp
@@ -704,6 +704,12 @@ SymConvertNameToAddress(const char * FunctionOrVariableName, PBOOLEAN WasFound)
         std::string ObjectName(FunctionOrVariableName);
         FinalModuleName = ModuleName + "!" + FunctionOrVariableName;
     }
+    else
+    {
+        std::string ModuleName(FunctionOrVariableName);
+        FinalModuleName = ModuleName;
+
+    }
 
     if (SymFromName(GetCurrentProcess(), FinalModuleName.c_str(), Symbol))
     {


### PR DESCRIPTION
# Description

This is the last commit before releasing HyperDbg v0.2.0.0. 

## [0.2.0.0] - 2023-05-03
The second (2nd) of the HyperDbg Debugger.

### Added
- HyperDbg Software Development Kit (SDK) is now available 
- **flush()** function in script engine ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/events/flush))
- **memcpy()** function in script engine ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/memory/memcpy))

### Changed
- Global code refactor and fixing bugs!
- Compiling HyperDbg by using the latest Windows 11 WDK
- **enable_event** function name changed to **event_enable** ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/events/event_enable))
- **disable_event** function name changed to **event_disable** ([link](https://docs.hyperdbg.org/commands/scripting-language/functions/events/event_disable))
- The "**settings**" command now preserves the configurations in the config file
- The communication buffer is now separated from the hyperlogger buffer chunks and the buffer size is increased X10 times ([link](https://docs.hyperdbg.org/tips-and-tricks/misc/increase-communication-buffer-size)) 
- Zydis submodule is updated to version 4 ([link](https://github.com/zyantific/zydis/releases/tag/v4.0.0)) 
