### PR TITLE
Fix issue with compilation not working if space is included in the solution's path

### DIFF
--- a/hyperdbg/hprdbgctrl/hprdbgctrl.vcxproj
+++ b/hyperdbg/hprdbgctrl/hprdbgctrl.vcxproj
@@ -116,7 +116,7 @@
       </Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>msbuild $(SolutionDir)\dependencies\zydis\msvc\Zydis.sln /m /p:Configuration="Release MT" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir=$(SolutionDir)/libraries/zydis/user/</Command>
+      <Command>msbuild "$(SolutionDir)dependencies\zydis\msvc\Zydis.sln" /m /p:Configuration="Release MT" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir="$(SolutionDir)libraries\zydis\user"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/hyperdbg/hprdbgctrl/hprdbgctrl.vcxproj
+++ b/hyperdbg/hprdbgctrl/hprdbgctrl.vcxproj
@@ -52,7 +52,7 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)build\bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)build\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
+    <PreBuildEventUseInBuild>true</PreBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
     <TargetName>HPRDBGCTRL</TargetName>
@@ -84,7 +84,7 @@
       </Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>msbuild "$(SolutionDir)dependencies\zydis\msvc\Zydis.sln" /m /p:Configuration="Release MT" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir="$(SolutionDir)libraries\zydis\user\"</Command>
+      <Command>msbuild "$(SolutionDir)dependencies\zydis\msvc\Zydis.sln" /m /p:Configuration="Release MT" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir="$(SolutionDir)libraries\zydis\user"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">

--- a/hyperdbg/hprdbgctrl/hprdbgctrl.vcxproj
+++ b/hyperdbg/hprdbgctrl/hprdbgctrl.vcxproj
@@ -52,6 +52,7 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)build\bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)build\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
     <TargetName>HPRDBGCTRL</TargetName>
@@ -83,7 +84,7 @@
       </Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>msbuild $(SolutionDir)\dependencies\zydis\msvc\Zydis.sln /m /p:Configuration="Release MT" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir=$(SolutionDir)/libraries/zydis/user/</Command>
+      <Command>msbuild "$(SolutionDir)dependencies\zydis\msvc\Zydis.sln" /m /p:Configuration="Release MT" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir="$(SolutionDir)libraries\zydis\user\"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">

--- a/hyperdbg/hprdbghv/hprdbghv.vcxproj
+++ b/hyperdbg/hprdbghv/hprdbghv.vcxproj
@@ -115,7 +115,7 @@
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
     </DriverSign>
     <PreBuildEvent>
-      <Command>msbuild $(SolutionDir)\dependencies\zydis\msvc\Zydis.sln /m /p:Configuration="Release Kernel" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir=$(SolutionDir)/libraries/zydis/kernel/ </Command>
+      <Command>msbuild "$(SolutionDir)dependencies\zydis\msvc\Zydis.sln" /m /p:Configuration="Release Kernel" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir="$(SolutionDir)libraries\zydis\kernel"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/hyperdbg/hprdbghv/hprdbghv.vcxproj
+++ b/hyperdbg/hprdbghv/hprdbghv.vcxproj
@@ -88,7 +88,7 @@
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
     </DriverSign>
     <PreBuildEvent>
-      <Command>msbuild $(SolutionDir)\dependencies\zydis\msvc\Zydis.sln /m /p:Configuration="Release Kernel" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir=$(SolutionDir)/libraries/zydis/kernel/ </Command>
+      <Command>msbuild "$(SolutionDir)dependencies\zydis\msvc\Zydis.sln" /m /p:Configuration="Release Kernel" /p:Platform=$(Platform) /target:zydis /target:zycore /p:OutDir="$(SolutionDir)libraries\zydis\kernel"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">


### PR DESCRIPTION
# Description

When a space is in the solution's path, the msbuild command used in the `hyperdbgctrl` and `hyperdbghv` projects' Pre-Build Events thinks that multiple projects are being specified.

This PR fixes said issue by adding quotation marks to the command and removing the backslash at the end of the path used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

