### PR TITLE
Update namedpipe.cpp

### DIFF
--- a/hyperdbg/hprdbgctrl/code/debugger/communication/namedpipe.cpp
+++ b/hyperdbg/hprdbgctrl/code/debugger/communication/namedpipe.cpp
@@ -316,10 +316,6 @@ NamedPipeClientSendMessage(HANDLE PipeHandle, char * BufferToSend, int BufferSiz
                      GetLastError());
         CloseHandle(PipeHandle);
 
-        //
-        // Error
-        //
-        CloseHandle(PipeHandle);
         return FALSE;
     }
     else


### PR DESCRIPTION
Bug fix

Two calls to CloseHandle were being made.
If this behavior is intended please explain why.
