### PR TITLE
Add interception for commands in remote computer

### DIFF
--- a/hyperdbg/hprdbgctrl/code/debugger/core/interpreter.cpp
+++ b/hyperdbg/hprdbgctrl/code/debugger/core/interpreter.cpp
@@ -172,7 +172,12 @@ HyperDbgInterpreter(char * Command)
         }
         else
         {
+            //
+            // Disable the breakpoints and events while executing the command in the remote computer
+            //
+            KdSendTestQueryPacketToDebuggee(TEST_BREAKPOINT_TURN_OFF_BPS_ANS_EVENTS_FOR_COMMANDS_IN_REMOTE_COMPUTER);
             KdSendUserInputPacketToDebuggee(Command, strlen(Command) + 1, FALSE);
+            KdSendTestQueryPacketToDebuggee(TEST_BREAKPOINT_TURN_ON_BPS_ANS_EVENTS_FOR_COMMANDS_IN_REMOTE_COMPUTER);
         }
 
         //

--- a/hyperdbg/hprdbgkd/code/debugger/commands/BreakpointCommands.c
+++ b/hyperdbg/hprdbgkd/code/debugger/commands/BreakpointCommands.c
@@ -538,7 +538,7 @@ BreakpointCheckAndHandleDebuggerDefinedBreakpoints(PROCESSOR_DEBUGGING_STATE * D
                 //
                 // Check if we need to handle the breakpoint by user or just ignore handling it
                 //
-                if (!IgnoreUserHandling && !g_InterceptBreakpoints)
+                if (!IgnoreUserHandling && !g_InterceptBreakpoints && !g_InterceptBreakpointsAndEventsForCommandsInRemoteComputer)
                 {
                     //
                     // *** It's not safe to access CurrentBreakpointDesc anymore as the
@@ -659,7 +659,7 @@ BreakpointHandleBpTraps(UINT32 CoreId)
             // , we should always call BreakpointCheckAndHandleDebuggerDefinedBreakpoints first to handle the breakpoint
             //
 
-            if (g_InterceptBreakpoints)
+            if (g_InterceptBreakpoints || g_InterceptBreakpointsAndEventsForCommandsInRemoteComputer)
             {
                 //
                 // re-inject back to the guest as not handled if the interception is on and the breakpoint is not from the Hyperdbg's breakpoints

--- a/hyperdbg/hprdbgkd/code/debugger/core/Debugger.c
+++ b/hyperdbg/hprdbgkd/code/debugger/core/Debugger.c
@@ -702,7 +702,7 @@ DebuggerTriggerEvents(VMM_EVENT_TYPE_ENUM                   EventType,
     //
     // Check if triggering debugging actions are allowed or not
     //
-    if (!g_EnableDebuggerEvents)
+    if (!g_EnableDebuggerEvents || g_InterceptBreakpointsAndEventsForCommandsInRemoteComputer)
     {
         //
         // Debugger is not enabled

--- a/hyperdbg/hprdbgkd/code/debugger/kernel-level/Kd.c
+++ b/hyperdbg/hprdbgkd/code/debugger/kernel-level/Kd.c
@@ -2207,9 +2207,31 @@ KdDispatchAndPerformCommandsFromDebugger(PROCESSOR_DEBUGGING_STATE * DbgState)
                 case TEST_BREAKPOINT_TURN_ON_BPS:
 
                     //
-                    // Turn off the breakpoint interception
+                    // Turn on the breakpoint interception
                     //
                     g_InterceptBreakpoints = FALSE;
+
+                    TestQueryPacket->KernelStatus = DEBUGGER_OPERATION_WAS_SUCCESSFUL;
+
+                    break;
+
+                case TEST_BREAKPOINT_TURN_OFF_BPS_ANS_EVENTS_FOR_COMMANDS_IN_REMOTE_COMPUTER:
+
+                    //
+                    // Turn off the breakpoints and events interception before executing the commands in the remote computer
+                    //
+                    g_InterceptBreakpointsAndEventsForCommandsInRemoteComputer = TRUE;
+
+                    TestQueryPacket->KernelStatus = DEBUGGER_OPERATION_WAS_SUCCESSFUL;
+
+                    break;
+
+                case TEST_BREAKPOINT_TURN_ON_BPS_ANS_EVENTS_FOR_COMMANDS_IN_REMOTE_COMPUTER:
+
+                    //
+                    // Turn on the breakpoints and events interception after finishing the commands in the remote computer
+                    //
+                    g_InterceptBreakpointsAndEventsForCommandsInRemoteComputer = FALSE;
 
                     TestQueryPacket->KernelStatus = DEBUGGER_OPERATION_WAS_SUCCESSFUL;
 

--- a/hyperdbg/hprdbgkd/header/globals/Global.h
+++ b/hyperdbg/hprdbgkd/header/globals/Global.h
@@ -177,3 +177,11 @@ UINT64 g_KernelTestR12;
  *
  */
 BOOLEAN g_IsWaitingForUserModeProcessEntryToBeCalled;
+
+/**
+* @brief To avoid getting stuck from getting hit from the breakpoints while executing
+* the commands in the remote computer, for example, bp NtQuerySystemInformation and lm,
+* the debugger should intercept the breakponts and events.
+*
+*/
+BOOLEAN g_InterceptBreakpointsAndEventsForCommandsInRemoteComputer;

--- a/hyperdbg/include/SDK/Headers/RequestStructures.h
+++ b/hyperdbg/include/SDK/Headers/RequestStructures.h
@@ -266,12 +266,13 @@ typedef struct _DEBUGGER_FLUSH_LOGGING_BUFFERS
  */
 typedef enum _DEBUGGER_TEST_QUERY_STATE
 {
-    TEST_QUERY_HALTING_CORE_STATUS     = 1, // Query constant to show detail of halting of core
-    TEST_QUERY_PREALLOCATED_POOL_STATE = 2, // Query pre-allocated pool state
-    TEST_QUERY_TRAP_STATE              = 3, // Query trap state
-    TEST_BREAKPOINT_TURN_OFF_BPS       = 4, // Turn off the breakpoints
-    TEST_BREAKPOINT_TURN_ON_BPS        = 5, // Turn on the breakpoints
-
+    TEST_QUERY_HALTING_CORE_STATUS                                          = 1, // Query constant to show detail of halting of core
+    TEST_QUERY_PREALLOCATED_POOL_STATE                                      = 2, // Query pre-allocated pool state
+    TEST_QUERY_TRAP_STATE                                                   = 3, // Query trap state
+    TEST_BREAKPOINT_TURN_OFF_BPS                                            = 4, // Turn off the breakpoints
+    TEST_BREAKPOINT_TURN_ON_BPS                                             = 5, // Turn on the breakpoints
+    TEST_BREAKPOINT_TURN_OFF_BPS_ANS_EVENTS_FOR_COMMANDS_IN_REMOTE_COMPUTER = 6, // Turn off the breakpoints and events for executing the commands in the remote computer
+    TEST_BREAKPOINT_TURN_ON_BPS_ANS_EVENTS_FOR_COMMANDS_IN_REMOTE_COMPUTER  = 7, // Turn on the breakpoints and events for executing the commands in the remote computer
 } DEBUGGER_TEST_QUERY_STATE;
 
 /**


### PR DESCRIPTION
# Description

```
bp NtQuerySystemInformation
lm
```
causes the debugger getting stuck.

The reason is that the debuggee  gets hit by the breakpoints or events to pause while executing the command like `lm`, which the debugger always waits for the command finishing.

https://github.com/HyperDbg/HyperDbg/blob/8a3d5b2a78cd2c41cac1c2436c03487f876ee4d8/hyperdbg/hprdbgctrl/code/debugger/kernel-level/kd.cpp#L1087

So, I disable the breakpoints and events trigged while executing the commands in the remote computer.