### PR TITLE
Fix the bug with exit in debugger mode

### DIFF
--- a/hyperdbg/hprdbgctrl/code/debugger/commands/debugging-commands/exit.cpp
+++ b/hyperdbg/hprdbgctrl/code/debugger/commands/debugging-commands/exit.cpp
@@ -14,7 +14,9 @@
 //
 // Global Variables
 //
-extern HANDLE g_DeviceHandle;
+extern HANDLE  g_DeviceHandle;
+extern BOOLEAN g_IsConnectedToHyperDbgLocally;
+extern BOOLEAN g_IsSerialConnectedToRemoteDebuggee;
 
 /**
  * @brief help of the exit command
@@ -47,12 +49,27 @@ CommandExit(vector<string> SplittedCommand, string Command)
         return;
     }
 
-    //
-    // unload and exit if the vmm module is loaded
-    //
-    if (g_DeviceHandle)
+    if (g_IsConnectedToHyperDbgLocally)
     {
-        HyperDbgUnloadVmm();
+        //
+        // It is in VMI mode
+        //
+
+        //
+        // unload and exit if the vmm module is loaded
+        //
+        if (g_DeviceHandle)
+        {
+            HyperDbgUnloadVmm();
+        }
+    }
+    else if (g_IsSerialConnectedToRemoteDebuggee)
+    {
+        //
+        // It is in debugger mode
+        //
+
+        KdCloseConnection();
     }
 
     exit(0);


### PR DESCRIPTION
# Description

https://github.com/HyperDbg/HyperDbg/issues/228

`exit` in debugger mode without `.debug close` or `KdCloseConnection()`  beforehand would cause debuggee frozen.