### PR TITLE
Fix out-of-bound vulnerability in AppendWchar

### DIFF
--- a/hyperdbg/script-engine/code/common.c
+++ b/hyperdbg/script-engine/code/common.c
@@ -238,7 +238,7 @@ AppendWchar(PTOKEN Token, wchar_t c)
     //
     // Append the new charcter to the string
     //
-    wcscat(Token->Value, &c);
+    wcsncat(Token->Value, &c, 1);
     Token->Len += 2;
 }
 


### PR DESCRIPTION
# Description

In local debugging mode
```
.script manual-test-cases_50-59.ds
```
![image](https://github.com/HyperDbg/HyperDbg/assets/54590608/831c4854-7ed3-430b-98c6-0e625a41d563)


