### PR TITLE
Support character underscore for pseudo register name

### DIFF
--- a/hyperdbg/script-engine/code/scanner.c
+++ b/hyperdbg/script-engine/code/scanner.c
@@ -367,7 +367,10 @@ GetToken(char * c, char * str)
         *c = sgetc(str);
         if (IsLetter(*c))
         {
-            while (IsLetter(*c) || IsDecimal(*c))
+            //
+            // Append valid characters for pseudo registers' name
+            //
+            while (IsLetter(*c) || IsDecimal(*c) || *c == '_')
             {
                 Append(Token, *c);
                 *c = sgetc(str);


### PR DESCRIPTION
# Description
https://github.com/HyperDbg/HyperDbg/issues/311
Support character underscore for pseudo register name
