### PR TITLE
fix: Invept invalidation using out of scope descriptor

### DIFF
--- a/hyperdbg/hprdbghv/code/vmm/ept/Invept.c
+++ b/hyperdbg/hprdbghv/code/vmm/ept/Invept.c
@@ -21,9 +21,9 @@
 UCHAR
 EptInvept(_In_ UINT32 Type, _In_ INVEPT_DESCRIPTOR * Descriptor)
 {
+    INVEPT_DESCRIPTOR ZeroDescriptor = {0};
     if (!Descriptor)
     {
-        INVEPT_DESCRIPTOR ZeroDescriptor = {0};
         Descriptor                       = &ZeroDescriptor;
     }
 


### PR DESCRIPTION
# Description

Invept invalidation is using an out of scope descriptor on the stack.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
