### PR TITLE
Fix MTRR range loop typo

### DIFF
--- a/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
@@ -249,8 +249,8 @@ EptBuildMtrrMap(VOID)
             {
                 Descriptor                      = &g_EptState->MemoryRanges[g_EptState->NumberOfEnabledMemoryRanges++];
                 Descriptor->MemoryType          = K16Types.s.Types[j];
-                Descriptor->PhysicalBaseAddress = K16Base + (K16Size * j);
-                Descriptor->PhysicalEndAddress  = K16Base + (K16Size * j) + (K16Size - 1);
+                Descriptor->PhysicalBaseAddress = (K16Base + (i * K16Size * 8)) + (K16Size * j);
+                Descriptor->PhysicalEndAddress  = (K16Base + (i * K16Size * 8)) + (K16Size * j) + (K16Size - 1);
                 Descriptor->FixedRange          = TRUE;
             }
         }


### PR DESCRIPTION
# Description
This commit is a fixed redo of ed5ab28 to correctly index into the fixed range MTRRs ranging from `IA32_MTRR_FIX16K_80000` up to `A0000`.

References #323

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)