### PR TITLE
MTRR fixes

### DIFF
--- a/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
@@ -183,36 +183,6 @@ EptBuildMtrrMap(VOID)
     g_EptState->DefaultMemoryType = MTRRDefType.DefaultMemoryType;
 
     //
-    // If IA32_MTRRCAP[bit 11] is set, the processor supports the SMRR interface to restrict access to a specified
-    // memory address range used by system-management mode (SMM) software (see Section 31.4.2.1). If the SMRR
-    // interface is supported, SMM software is strongly encouraged to use it to protect the SMI code and data stored by
-    // SMI handler in the SMRAM region.
-    //
-    // The system-management range registers consist of a pair of MSRs (see Figure 11-8). The IA32_SMRR_PHYSBASE
-    // MSR defines the base address for the SMRAM memory range and the memory type used to access it in SMM. The
-    // IA32_SMRR_PHYSMASK MSR contains a valid bit and a mask that determines the SMRAM address range protected
-    // by the SMRR interface. These MSRs may be written only in SMM;
-    // an attempt to write them outside of SMM causes a general-protection exception.
-    //
-    if (MTRRCap.SmrrSupported)
-    {
-        CurrentPhysBase.AsUInt = __readmsr(IA32_SMRR_PHYSBASE);
-        CurrentPhysMask.AsUInt = __readmsr(IA32_SMRR_PHYSMASK);
-
-        if (CurrentPhysMask.Valid)
-        {
-            Descriptor                      = &g_EptState->MemoryRanges[g_EptState->NumberOfEnabledMemoryRanges++];
-            Descriptor->PhysicalBaseAddress = CurrentPhysBase.PageFrameNumber * PAGE_SIZE;
-
-            _BitScanForward64(&NumberOfBitsInMask, CurrentPhysMask.PageFrameNumber * PAGE_SIZE);
-
-            Descriptor->PhysicalEndAddress = Descriptor->PhysicalBaseAddress + ((1ULL << NumberOfBitsInMask) - 1ULL);
-            Descriptor->MemoryType         = CurrentPhysBase.Type;
-            Descriptor->FixedRange         = FALSE;
-        }
-    }
-
-    //
     // The fixed memory ranges are mapped with 11 fixed-range registers of 64 bits each. Each of these registers is
     // divided into 8-bit fields that are used to specify the memory type for each of the sub-ranges the register controls:
     //  - Register IA32_MTRR_FIX64K_00000 - Maps the 512-KByte address range from 0H to 7FFFFH. This range

--- a/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
@@ -248,9 +248,9 @@ EptBuildMtrrMap(VOID)
             for (unsigned int j = 0; j < 8; j++)
             {
                 Descriptor                      = &g_EptState->MemoryRanges[g_EptState->NumberOfEnabledMemoryRanges++];
-                Descriptor->MemoryType          = K16Types.s.Types[i];
-                Descriptor->PhysicalBaseAddress = K16Base + (K16Size * i);
-                Descriptor->PhysicalEndAddress  = K16Base + (K16Size * i) + (K16Size - 1);
+                Descriptor->MemoryType          = K16Types.s.Types[j];
+                Descriptor->PhysicalBaseAddress = (K16Base + (i * K16Size * 8)) + (K16Size * j);
+                Descriptor->PhysicalEndAddress  = (K16Base + (i * K16Size * 8)) + (K16Size * j) + (K16Size - 1);
                 Descriptor->FixedRange          = TRUE;
             }
         }


### PR DESCRIPTION
# Description
1. Redo ed5ab28 to correctly index into the fixed range MTRRs ranging from `IA32_MTRR_FIX16K_80000` up to `A0000`.
2. Do not treat the SMRAM range returned via the SMRR interface as a variable range MTRR (with incorrect cache attributes due to the range being inaccessible outside SMM).

References #323

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)