### PR TITLE
v0.8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1.0] - 2024-XX-XX
+## [0.8.1.0] - 2024-02-01
 New release of the HyperDbg Debugger thanks to [@mattiwatti](https://github.com/Mattiwatti).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1.0] - 2024-XX-XX
+New release of the HyperDbg Debugger thanks to [@mattiwatti](https://github.com/Mattiwatti).
+
+### Changed
+- Fix the issue of not intercepting memory monitoring on non-contiguous physical memory allocations
+- The speed of memory read/write/execution interception is enhanced by avoiding triggering out-of-range events
+
+### Added
+- The **!monitor** command now supports length in parameters ([link](https://docs.hyperdbg.org/commands/extension-commands/monitor#syntax))
+
 ## [0.8.0.0] - 2024-01-28
 New release of the HyperDbg Debugger thanks to [@mattiwatti](https://github.com/Mattiwatti).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.8.1.0] - 2024-02-01
-New release of the HyperDbg Debugger thanks to [@mattiwatti](https://github.com/Mattiwatti).
+New release of the HyperDbg Debugger.
 
 ### Changed
 - Fix the issue of not intercepting memory monitoring on non-contiguous physical memory allocations

--- a/hyperdbg/hprdbghv/code/hooks/ept-hook/EptHook.c
+++ b/hyperdbg/hprdbghv/code/hooks/ept-hook/EptHook.c
@@ -974,38 +974,41 @@ EptHookInstructionMemory(PEPT_HOOKED_PAGE_DETAIL Hook,
  * This function have to be called through a VMCALL in VMX Root Mode
  *
  * @param VCpu The virtual processor's state
- * @param TargetAddress The address of function or memory address to be hooked
- * @param HookFunction The function that will be called when hook triggered
+ * @param HookingDetails The address of function or memory address to be hooked
  * @param ProcessCr3 The process cr3 to translate based on that process's cr3
- * @param UnsetRead Hook READ Access
- * @param UnsetWrite Hook WRITE Access
- * @param UnsetExecute Hook EXECUTE Access
- * @param EptHiddenHook !epthook2-like events
+ * @param PageHookMask Mask hook of the page
  *
  * @return BOOLEAN Returns true if the hook was successful or false if there was an error
  */
 BOOLEAN
-EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
-                        PVOID                   TargetAddress,
-                        PVOID                   HookFunction,
-                        CR3_TYPE                ProcessCr3,
-                        BOOLEAN                 UnsetRead,
-                        BOOLEAN                 UnsetWrite,
-                        BOOLEAN                 UnsetExecute,
-                        BOOLEAN                 EptHiddenHook)
+EptHookPerformPageHookMonitorAndInlineHook(VIRTUAL_MACHINE_STATE * VCpu,
+                                           PVOID                   HookingDetails,
+                                           CR3_TYPE                ProcessCr3,
+                                           UINT32                  PageHookMask)
 {
     ULONG                   ProcessorsCount;
     EPT_PML1_ENTRY          ChangedEntry;
     INVEPT_DESCRIPTOR       Descriptor;
     SIZE_T                  PhysicalBaseAddress;
-    PVOID                   VirtualTarget;
+    PVOID                   AlignedTargetVa;
     PVOID                   TargetBuffer;
+    PVOID                   TargetAddress;
+    PVOID                   HookFunction;
     UINT64                  TargetAddressInSafeMemory;
     PEPT_PML1_ENTRY         TargetPage;
     PEPT_HOOKED_PAGE_DETAIL HookedPage;
     CR3_TYPE                Cr3OfCurrentProcess;
-    PLIST_ENTRY             TempList    = 0;
-    PEPT_HOOKED_PAGE_DETAIL HookedEntry = NULL;
+    PLIST_ENTRY             TempList      = 0;
+    PEPT_HOOKED_PAGE_DETAIL HookedEntry   = NULL;
+    BOOLEAN                 UnsetExecute  = FALSE;
+    BOOLEAN                 UnsetRead     = FALSE;
+    BOOLEAN                 UnsetWrite    = FALSE;
+    BOOLEAN                 EptHiddenHook = FALSE;
+
+    UnsetRead     = (PageHookMask & PAGE_ATTRIB_READ) ? TRUE : FALSE;
+    UnsetWrite    = (PageHookMask & PAGE_ATTRIB_WRITE) ? TRUE : FALSE;
+    UnsetExecute  = (PageHookMask & PAGE_ATTRIB_EXEC) ? TRUE : FALSE;
+    EptHiddenHook = (PageHookMask & PAGE_ATTRIB_EXEC_HIDDEN_HOOK) ? TRUE : FALSE;
 
     //
     // Get number of processors
@@ -1017,7 +1020,16 @@ EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
     // This function will return NULL if the physical address was not already mapped in
     // virtual memory.
     //
-    VirtualTarget = PAGE_ALIGN(TargetAddress);
+    if (EptHiddenHook)
+    {
+        TargetAddress = ((EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2 *)HookingDetails)->TargetAddress;
+    }
+    else
+    {
+        TargetAddress = ((EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR *)HookingDetails)->StartAddress;
+    }
+
+    AlignedTargetVa = PAGE_ALIGN(TargetAddress);
 
     //
     // Here we have to change the CR3, it is because we are in SYSTEM process
@@ -1026,9 +1038,9 @@ EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
     //
 
     //
-    // Find cr3 of target core
+    // based on the CR3 of target core
     //
-    PhysicalBaseAddress = (SIZE_T)VirtualAddressToPhysicalAddressByProcessCr3(VirtualTarget, ProcessCr3);
+    PhysicalBaseAddress = (SIZE_T)VirtualAddressToPhysicalAddressByProcessCr3(AlignedTargetVa, ProcessCr3);
 
     if (!PhysicalBaseAddress)
     {
@@ -1079,6 +1091,48 @@ EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
     HookedPage->PhysicalBaseAddress = PhysicalBaseAddress;
 
     //
+    // If it's a monitor hook, then we need to hold the address of the start
+    // physical address as well as the end physical address, plus tagging information
+    //
+    if (!EptHiddenHook)
+    {
+        //
+        // Save the target tag
+        //
+        HookedPage->HookingTag = ((EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR *)HookingDetails)->Tag;
+
+        //
+        // Save the start of the target physical address
+        //
+        HookedPage->StartOfTargetPhysicalAddress = (SIZE_T)VirtualAddressToPhysicalAddressByProcessCr3(
+            ((EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR *)HookingDetails)->StartAddress,
+            ProcessCr3);
+
+        if (!HookedPage->StartOfTargetPhysicalAddress)
+        {
+            PoolManagerFreePool(HookedPage);
+
+            VmmCallbackSetLastError(DEBUGGER_ERROR_INVALID_ADDRESS);
+            return FALSE;
+        }
+
+        //
+        // Save the end of the target physical address
+        //
+        HookedPage->EndOfTargetPhysicalAddress = (SIZE_T)VirtualAddressToPhysicalAddressByProcessCr3(
+            ((EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR *)HookingDetails)->EndAddress,
+            ProcessCr3);
+
+        if (!HookedPage->EndOfTargetPhysicalAddress)
+        {
+            PoolManagerFreePool(HookedPage);
+
+            VmmCallbackSetLastError(DEBUGGER_ERROR_INVALID_ADDRESS);
+            return FALSE;
+        }
+    }
+
+    //
     // Fake page content physical address
     //
     HookedPage->PhysicalBaseAddressOfFakePageContents = (SIZE_T)VirtualAddressToPhysicalAddress(&HookedPage->FakePageContents[0]) / PAGE_SIZE;
@@ -1100,7 +1154,7 @@ EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
         // The following line can't be used in user mode addresses
         // RtlCopyBytes(&HookedPage->FakePageContents, VirtualTarget, PAGE_SIZE);
         //
-        MemoryMapperReadMemorySafe(VirtualTarget, &HookedPage->FakePageContents, PAGE_SIZE);
+        MemoryMapperReadMemorySafe(AlignedTargetVa, &HookedPage->FakePageContents, PAGE_SIZE);
 
         //
         // Restore to original process
@@ -1118,9 +1172,13 @@ EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
         // Make sure if handler function is valid or if it's default
         // then we set it to the default hanlder
         //
-        if (HookFunction == NULL)
+        if (((EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2 *)HookingDetails)->HookFunction == NULL)
         {
             HookFunction = AsmGeneralDetourHook;
+        }
+        else
+        {
+            HookFunction = ((EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2 *)HookingDetails)->HookFunction;
         }
 
         //
@@ -1268,78 +1326,94 @@ EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
  * VMX root-mode directly, it should also invalidate EPT caches (by the caller)
  *
  * @param VCpu The virtual processor's state
- * @param TargetAddress The address of function or memory address to be hooked
- * @param HookFunction The function that will be called when hook triggered
+ * @param EptHook2AddressDetails The address details for inline EPT hooks
+ * @param MemoryAddressDetails The address details for monitor EPT hooks
  * @param ProcessId The process id to translate based on that process's cr3
- * @param SetHookForRead Hook READ Access
- * @param SetHookForWrite Hook WRITE Access
- * @param SetHookForExec Hook EXECUTE Access
  * @param EptHiddenHook2 epthook2 style hook
  * @param ApplyDirectlyFromVmxRoot should it be directly applied from VMX-root mode or not
  *
  * @return BOOLEAN Returns true if the hook was successful or false if there was an error
  */
 BOOLEAN
-EptHook2PerformHook(VIRTUAL_MACHINE_STATE * VCpu,
-                    PVOID                   TargetAddress,
-                    PVOID                   HookFunction,
-                    UINT32                  ProcessId,
-                    BOOLEAN                 SetHookForRead,
-                    BOOLEAN                 SetHookForWrite,
-                    BOOLEAN                 SetHookForExec,
-                    BOOLEAN                 EptHiddenHook2,
-                    BOOLEAN                 ApplyDirectlyFromVmxRoot)
+EptHookPerformMemoryOrInlineHook(VIRTUAL_MACHINE_STATE *                        VCpu,
+                                 EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2 *       EptHook2AddressDetails,
+                                 EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * MemoryAddressDetails,
+                                 UINT32                                         ProcessId,
+                                 BOOLEAN                                        EptHiddenHook2,
+                                 BOOLEAN                                        ApplyDirectlyFromVmxRoot)
 {
-    UINT32 PageHookMask = 0;
+    UINT32 PageHookMask        = 0;
+    PVOID  HookDetailsToVmcall = NULL;
 
     //
     // Check for the features to avoid EPT Violation problems
     //
-    if (SetHookForExec && !g_CompatibilityCheck.ExecuteOnlySupport)
+    if (MemoryAddressDetails != NULL)
+    {
+        HookDetailsToVmcall = MemoryAddressDetails;
+
+        if (MemoryAddressDetails->SetHookForExec &&
+            !g_CompatibilityCheck.ExecuteOnlySupport)
+        {
+            //
+            // In the current design of hyperdbg we use execute-only pages
+            // to implement hidden hooks for exec page, so your processor doesn't
+            // have this feature and you have to implment it in other ways :(
+            //
+            return FALSE;
+        }
+
+        if (!MemoryAddressDetails->SetHookForWrite && MemoryAddressDetails->SetHookForRead)
+        {
+            //
+            // The hidden hook with Write Enable and Read Disabled will cause EPT violation!
+            // fixed
+            return FALSE;
+        }
+
+        if (MemoryAddressDetails->SetHookForRead)
+        {
+            PageHookMask |= PAGE_ATTRIB_READ;
+        }
+        if (MemoryAddressDetails->SetHookForWrite)
+        {
+            PageHookMask |= PAGE_ATTRIB_WRITE;
+        }
+        if (MemoryAddressDetails->SetHookForExec)
+        {
+            PageHookMask |= PAGE_ATTRIB_EXEC;
+        }
+    }
+    else if (EptHook2AddressDetails != NULL)
+    {
+        HookDetailsToVmcall = EptHook2AddressDetails;
+
+        //
+        // Initialize the list of ept hook detours if it's not already initialized
+        //
+        if (!g_IsEptHook2sDetourListInitialized)
+        {
+            g_IsEptHook2sDetourListInitialized = TRUE;
+
+            InitializeListHead(&g_EptHook2sDetourListHead);
+        }
+
+        if (EptHiddenHook2)
+        {
+            PageHookMask |= PAGE_ATTRIB_EXEC_HIDDEN_HOOK;
+        }
+    }
+    else
     {
         //
-        // In the current design of hyperdbg we use execute-only pages
-        // to implement hidden hooks for exec page, so your processor doesn't
-        // have this feature and you have to implment it in other ways :(
+        // No details provided
         //
         return FALSE;
     }
 
-    if (!SetHookForWrite && SetHookForRead)
-    {
-        //
-        // The hidden hook with Write Enable and Read Disabled will cause EPT violation!
-        // fixed
-        return FALSE;
-    }
-
     //
-    // Initialize the list of ept hook detours if it's not already initialized
+    // Check if mask is valid or not
     //
-    if (!g_IsEptHook2sDetourListInitialized)
-    {
-        g_IsEptHook2sDetourListInitialized = TRUE;
-
-        InitializeListHead(&g_EptHook2sDetourListHead);
-    }
-
-    if (SetHookForRead)
-    {
-        PageHookMask |= PAGE_ATTRIB_READ;
-    }
-    if (SetHookForWrite)
-    {
-        PageHookMask |= PAGE_ATTRIB_WRITE;
-    }
-    if (SetHookForExec)
-    {
-        PageHookMask |= PAGE_ATTRIB_EXEC;
-    }
-    if (EptHiddenHook2)
-    {
-        PageHookMask |= PAGE_ATTRIB_EXEC_HIDDEN_HOOK;
-    }
-
     if (PageHookMask == 0)
     {
         //
@@ -1348,19 +1422,14 @@ EptHook2PerformHook(VIRTUAL_MACHINE_STATE * VCpu,
         return FALSE;
     }
 
-    //
-    // Move Attribute Mask to the upper 32 bits of the VMCALL Number
-    //
-    UINT64 VmcallNumber = ((UINT64)PageHookMask) << 32 | VMCALL_CHANGE_PAGE_ATTRIB;
-
     if (ApplyDirectlyFromVmxRoot)
     {
         DIRECT_VMCALL_PARAMETERS DirectVmcallOptions = {0};
-        DirectVmcallOptions.OptionalParam1           = TargetAddress;
-        DirectVmcallOptions.OptionalParam2           = HookFunction;
+        DirectVmcallOptions.OptionalParam1           = HookDetailsToVmcall;
+        DirectVmcallOptions.OptionalParam2           = PageHookMask;
         DirectVmcallOptions.OptionalParam3           = LayoutGetCurrentProcessCr3().Flags; // Process id is ignored while applied directly
 
-        if (DirectVmcallPerformVmcall(VCpu->CoreId, VmcallNumber, &DirectVmcallOptions) == STATUS_SUCCESS)
+        if (DirectVmcallPerformVmcall(VCpu->CoreId, VMCALL_CHANGE_PAGE_ATTRIB, &DirectVmcallOptions) == STATUS_SUCCESS)
         {
             return TRUE;
         }
@@ -1373,7 +1442,7 @@ EptHook2PerformHook(VIRTUAL_MACHINE_STATE * VCpu,
     {
         if (VmxGetCurrentLaunchState())
         {
-            if (AsmVmxVmcall(VmcallNumber, TargetAddress, HookFunction, LayoutGetCr3ByProcessId(ProcessId).Flags) == STATUS_SUCCESS)
+            if (AsmVmxVmcall(VMCALL_CHANGE_PAGE_ATTRIB, HookDetailsToVmcall, PageHookMask, LayoutGetCr3ByProcessId(ProcessId).Flags) == STATUS_SUCCESS)
             {
                 //
                 // Test log
@@ -1404,14 +1473,10 @@ EptHook2PerformHook(VIRTUAL_MACHINE_STATE * VCpu,
         }
         else
         {
-            if (EptHookPerformPageHook2(VCpu,
-                                        TargetAddress,
-                                        HookFunction,
-                                        LayoutGetCr3ByProcessId(ProcessId),
-                                        SetHookForRead,
-                                        SetHookForWrite,
-                                        SetHookForExec,
-                                        EptHiddenHook2) == TRUE)
+            if (EptHookPerformPageHookMonitorAndInlineHook(VCpu,
+                                                           HookDetailsToVmcall,
+                                                           LayoutGetCr3ByProcessId(ProcessId),
+                                                           PageHookMask) == TRUE)
             {
                 LogWarning("Hook applied (VM has not launched)");
                 return TRUE;
@@ -1428,29 +1493,60 @@ EptHook2PerformHook(VIRTUAL_MACHINE_STATE * VCpu,
 }
 
 /**
- * @brief This function applies EPT hook2 and monitor hooks to the target EPT table
+ * @brief This function applies EPT hook 2 (inline) to the target EPT table
  * @details this function should be called from VMX non-root mode
  *
  * @param VCpu The virtual processor's state
  * @param TargetAddress The address of function or memory address to be hooked
  * @param HookFunction The function that will be called when hook triggered
  * @param ProcessId The process id to translate based on that process's cr3
- * @param SetHookForRead Hook READ Access
- * @param SetHookForWrite Hook WRITE Access
- * @param SetHookForExec Hook EXECUTE Access
- * @param EptHiddenHook2 epthook2 style hook
  *
  * @return BOOLEAN Returns true if the hook was successful or false if there was an error
  */
 BOOLEAN
-EptHook2(VIRTUAL_MACHINE_STATE * VCpu,
-         PVOID                   TargetAddress,
-         PVOID                   HookFunction,
-         UINT32                  ProcessId,
-         BOOLEAN                 SetHookForRead,
-         BOOLEAN                 SetHookForWrite,
-         BOOLEAN                 SetHookForExec,
-         BOOLEAN                 EptHiddenHook2)
+EptHookInlineHook(VIRTUAL_MACHINE_STATE * VCpu,
+                  PVOID                   TargetAddress,
+                  PVOID                   HookFunction,
+                  UINT32                  ProcessId)
+{
+    EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2 HookingDetail = {0};
+
+    //
+    // Should be called from vmx non-root
+    //
+    if (VmxGetCurrentExecutionMode() == TRUE)
+    {
+        return FALSE;
+    }
+
+    //
+    // Set the hooking details
+    //
+    HookingDetail.TargetAddress = TargetAddress;
+    HookingDetail.HookFunction  = HookFunction;
+
+    return EptHookPerformMemoryOrInlineHook(VCpu,
+                                            &HookingDetail,
+                                            NULL,
+                                            ProcessId,
+                                            TRUE,
+                                            FALSE);
+}
+
+/**
+ * @brief This function applies monitor hooks to the target EPT table
+ * @details this function should be called from VMX non-root mode
+ *
+ * @param VCpu The virtual processor's state
+ * @param HookingDetails Monitor hooking details
+ * @param ProcessId The process id to translate based on that process's cr3
+ *
+ * @return BOOLEAN Returns true if the hook was successful or false if there was an error
+ */
+BOOLEAN
+EptHookMonitorHook(VIRTUAL_MACHINE_STATE *                        VCpu,
+                   EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * HookingDetails,
+                   UINT32                                         ProcessId)
 {
     //
     // Should be called from vmx non-root
@@ -1460,39 +1556,65 @@ EptHook2(VIRTUAL_MACHINE_STATE * VCpu,
         return FALSE;
     }
 
-    return EptHook2PerformHook(VCpu,
-                               TargetAddress,
-                               HookFunction,
-                               ProcessId,
-                               SetHookForRead,
-                               SetHookForWrite,
-                               SetHookForExec,
-                               EptHiddenHook2,
-                               FALSE);
+    return EptHookPerformMemoryOrInlineHook(VCpu,
+                                            NULL,
+                                            HookingDetails,
+                                            ProcessId,
+                                            FALSE,
+                                            FALSE);
 }
 
 /**
- * @brief This function applies EPT hook2 and monitor hooks to the target EPT table
+ * @brief This function applies EPT inline to the target EPT table
  * @details this function should be called from VMX root-mode
  *
  * @param VCpu The virtual processor's state
  * @param TargetAddress The address of function or memory address to be hooked
  * @param HookFunction The function that will be called when hook triggered
- * @param SetHookForRead Hook READ Access
- * @param SetHookForWrite Hook WRITE Access
- * @param SetHookForExec Hook EXECUTE Access
- * @param EptHiddenHook2 epthook2 style hook
  *
  * @return BOOLEAN Returns true if the hook was successful or false if there was an error
  */
 BOOLEAN
-EptHook2FromVmxRoot(VIRTUAL_MACHINE_STATE * VCpu,
-                    PVOID                   TargetAddress,
-                    PVOID                   HookFunction,
-                    BOOLEAN                 SetHookForRead,
-                    BOOLEAN                 SetHookForWrite,
-                    BOOLEAN                 SetHookForExec,
-                    BOOLEAN                 EptHiddenHook2)
+EptHookInlineHookFromVmxRoot(VIRTUAL_MACHINE_STATE * VCpu,
+                             PVOID                   TargetAddress,
+                             PVOID                   HookFunction)
+{
+    EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2 HookingDetail = {0};
+
+    //
+    // Should be called from vmx root-mode
+    //
+    if (VmxGetCurrentExecutionMode() == FALSE)
+    {
+        return FALSE;
+    }
+
+    //
+    // Configure the details
+    //
+    HookingDetail.TargetAddress = TargetAddress;
+    HookingDetail.HookFunction  = HookFunction;
+
+    return EptHookPerformMemoryOrInlineHook(VCpu,
+                                            &HookingDetail,
+                                            NULL,
+                                            NULL,
+                                            TRUE,
+                                            TRUE);
+}
+
+/**
+ * @brief This function applies EPT monitor hooks to the target EPT table
+ * @details this function should be called from VMX root-mode
+ *
+ * @param VCpu The virtual processor's state
+ * @param MemoryAddressDetails details of the target memory
+ *
+ * @return BOOLEAN Returns true if the hook was successful or false if there was an error
+ */
+BOOLEAN
+EptHookMonitorFromVmxRoot(VIRTUAL_MACHINE_STATE *                        VCpu,
+                          EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * MemoryAddressDetails)
 {
     //
     // Should be called from vmx root-mode
@@ -1502,19 +1624,16 @@ EptHook2FromVmxRoot(VIRTUAL_MACHINE_STATE * VCpu,
         return FALSE;
     }
 
-    return EptHook2PerformHook(VCpu,
-                               TargetAddress,
-                               HookFunction,
-                               NULL,
-                               SetHookForRead,
-                               SetHookForWrite,
-                               SetHookForExec,
-                               EptHiddenHook2,
-                               TRUE);
+    return EptHookPerformMemoryOrInlineHook(VCpu,
+                                            NULL,
+                                            MemoryAddressDetails,
+                                            NULL,
+                                            FALSE,
+                                            TRUE);
 }
 
 /**
- * @brief Handles page hooks
+ * @brief Handles page hooks (trigger events)
  *
  * @param VCpu The virtual processor's state
  * @param HookedEntryDetails The entry that describes the hooked page
@@ -1556,6 +1675,7 @@ EptHookHandleHookedPage(VIRTUAL_MACHINE_STATE *              VCpu,
     //
     // Set the last context
     //
+    LastContext->HookingTag      = HookedEntryDetails->HookingTag;
     LastContext->PhysicalAddress = PhysicalAddress;
     LastContext->VirtualAddress  = ExactAccessedVirtualAddress;
 
@@ -1744,9 +1864,9 @@ EptHookGetCountOfEpthooks(BOOLEAN IsEptHook2)
  * was not successful returns false
  */
 BOOLEAN
-EptHookUnHookSingleAddressDetours(PEPT_HOOKED_PAGE_DETAIL             HookedEntry,
-                                  BOOLEAN                             ApplyDirectlyFromVmxRoot,
-                                  EPT_SINGLE_HOOK_UNHOOKING_DETAILS * TargetUnhookingDetails)
+EptHookUnHookSingleAddressDetoursAndMonitor(PEPT_HOOKED_PAGE_DETAIL             HookedEntry,
+                                            BOOLEAN                             ApplyDirectlyFromVmxRoot,
+                                            EPT_SINGLE_HOOK_UNHOOKING_DETAILS * TargetUnhookingDetails)
 {
     //
     // Set the unhooking details
@@ -1775,7 +1895,10 @@ EptHookUnHookSingleAddressDetours(PEPT_HOOKED_PAGE_DETAIL             HookedEntr
     // Now that we removed this hidden detours hook, it is
     // time to remove it from g_EptHook2sDetourListHead
     //
-    EptHookRemoveEntryAndFreePoolFromEptHook2sDetourList(HookedEntry->VirtualAddress);
+    if (HookedEntry->IsExecutionHook)
+    {
+        EptHookRemoveEntryAndFreePoolFromEptHook2sDetourList(HookedEntry->VirtualAddress);
+    }
 
     //
     // remove the entry from the list
@@ -2107,19 +2230,19 @@ EptHookPerformUnHookSingleAddress(UINT64                              VirtualAdd
         else
         {
             //
-            // It's either a hidden detours or a monitor (read/write) entry
+            // It's either a hidden detours or a monitor (read/write/execute) entry
             //
             if (CurrEntity->PhysicalBaseAddress == PhysicalAddress)
             {
-                return EptHookUnHookSingleAddressDetours(CurrEntity,
-                                                         ApplyDirectlyFromVmxRoot,
-                                                         TargetUnhookingDetails);
+                return EptHookUnHookSingleAddressDetoursAndMonitor(CurrEntity,
+                                                                   ApplyDirectlyFromVmxRoot,
+                                                                   TargetUnhookingDetails);
             }
         }
     }
 
     //
-    // Nothing found , probably the list is not found
+    // Nothing found, probably the list is not found
     //
     return FALSE;
 }

--- a/hyperdbg/hprdbghv/code/hooks/syscall-hook/SsdtHook.c
+++ b/hyperdbg/hprdbghv/code/hooks/syscall-hook/SsdtHook.c
@@ -295,14 +295,10 @@ SyscallHookTest()
     //
     // THIS EXAMPLE IS NOT VALID ANYMORE, PLEASE USE !syscall OR !epthook2 COMMANDS
     //
-    if (EptHook2(&g_GuestState[KeGetCurrentProcessorNumberEx(NULL)],
-                 ApiLocationFromSSDTOfNtCreateFile,
-                 NtCreateFileHook,
-                 PsGetCurrentProcessId(),
-                 FALSE,
-                 FALSE,
-                 FALSE,
-                 TRUE))
+    if (EptHookInlineHook(&g_GuestState[KeGetCurrentProcessorNumberEx(NULL)],
+                          ApiLocationFromSSDTOfNtCreateFile,
+                          NtCreateFileHook,
+                          PsGetCurrentProcessId()))
     {
         LogInfo("Hook appkied to address of API Number : 0x%x at %llx\n", ApiNumberOfNtCreateFile, ApiLocationFromSSDTOfNtCreateFile);
     }

--- a/hyperdbg/hprdbghv/code/interface/Configuration.c
+++ b/hyperdbg/hprdbghv/code/interface/Configuration.c
@@ -253,39 +253,67 @@ ConfigureEptHookFromVmxRoot(PVOID TargetAddress)
 }
 
 /**
- * @brief This function allocates a buffer in VMX Non Root Mode and then invokes a VMCALL to set the hook
+ * @brief This function allocates a buffer in VMX Non Root Mode and then invokes a VMCALL to set the hook (inline)
  * @details this command uses hidden detours, this NOT be called from vmx-root mode
- *
  *
  * @param CoreId ID of the target core
  * @param TargetAddress The address of function or memory address to be hooked
  * @param HookFunction The function that will be called when hook triggered
  * @param ProcessId The process id to translate based on that process's cr3
- * @param SetHookForRead Hook READ Access
- * @param SetHookForWrite Hook WRITE Access
- * @param SetHookForExec Hook EXECUTE Access
- * @param EptHiddenHook2 epthook2 style hook
  *
  * @return BOOLEAN Returns true if the hook was successful or false if there was an error
  */
 BOOLEAN
-ConfigureEptHook2(UINT32  CoreId,
-                  PVOID   TargetAddress,
-                  PVOID   HookFunction,
-                  UINT32  ProcessId,
-                  BOOLEAN SetHookForRead,
-                  BOOLEAN SetHookForWrite,
-                  BOOLEAN SetHookForExec,
-                  BOOLEAN EptHiddenHook2)
+ConfigureEptHook2(UINT32 CoreId,
+                  PVOID  TargetAddress,
+                  PVOID  HookFunction,
+                  UINT32 ProcessId)
 {
-    return EptHook2(&g_GuestState[CoreId],
-                    TargetAddress,
-                    HookFunction,
-                    ProcessId,
-                    SetHookForRead,
-                    SetHookForWrite,
-                    SetHookForExec,
-                    EptHiddenHook2);
+    return EptHookInlineHook(&g_GuestState[CoreId],
+                             TargetAddress,
+                             HookFunction,
+                             ProcessId);
+}
+
+/**
+ * @brief This function allocates a buffer in VMX Non Root Mode and then invokes a VMCALL to set the hook
+ * @details this command uses hidden detours, this NOT be called from vmx-root mode
+ *
+ *
+ * @param CoreId ID of the target core
+ * @param HookingDetails Monitor hooking detail
+ * @param ProcessId The process id to translate based on that process's cr3
+ *
+ * @return BOOLEAN Returns true if the hook was successful or false if there was an error
+ */
+BOOLEAN
+ConfigureEptHookMonitor(UINT32                                         CoreId,
+                        EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * HookingDetails,
+                        UINT32                                         ProcessId)
+{
+    return EptHookMonitorHook(&g_GuestState[CoreId],
+                              HookingDetails,
+                              ProcessId);
+}
+
+/**
+ * @brief This function allocates a buffer in VMX Non Root Mode and then invokes a VMCALL to set the hook (inline EPT hook)
+ * @details this command uses hidden detours, this should be called from vmx-root mode
+ *
+ * @param CoreId ID of the target core
+ * @param TargetAddress The address of function or memory address to be hooked
+ * @param HookFunction The function that will be called when hook triggered
+ *
+ * @return BOOLEAN Returns true if the hook was successful or false if there was an error
+ */
+BOOLEAN
+ConfigureEptHook2FromVmxRoot(UINT32 CoreId,
+                             PVOID  TargetAddress,
+                             PVOID  HookFunction)
+{
+    return EptHookInlineHookFromVmxRoot(&g_GuestState[CoreId],
+                                        TargetAddress,
+                                        HookFunction);
 }
 
 /**
@@ -294,31 +322,15 @@ ConfigureEptHook2(UINT32  CoreId,
  *
  *
  * @param CoreId ID of the target core
- * @param TargetAddress The address of function or memory address to be hooked
- * @param HookFunction The function that will be called when hook triggered
- * @param SetHookForRead Hook READ Access
- * @param SetHookForWrite Hook WRITE Access
- * @param SetHookForExec Hook EXECUTE Access
- * @param EptHiddenHook2 epthook2 style hook
+ * @param MemoryAddressDetails Monitor hooking details
  *
  * @return BOOLEAN Returns true if the hook was successful or false if there was an error
  */
 BOOLEAN
-ConfigureEptHook2FromVmxRoot(UINT32  CoreId,
-                             PVOID   TargetAddress,
-                             PVOID   HookFunction,
-                             BOOLEAN SetHookForRead,
-                             BOOLEAN SetHookForWrite,
-                             BOOLEAN SetHookForExec,
-                             BOOLEAN EptHiddenHook2)
+ConfigureEptHookMonitorFromVmxRoot(UINT32                                         CoreId,
+                                   EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * MemoryAddressDetails)
 {
-    return EptHook2FromVmxRoot(&g_GuestState[CoreId],
-                               TargetAddress,
-                               HookFunction,
-                               SetHookForRead,
-                               SetHookForWrite,
-                               SetHookForExec,
-                               EptHiddenHook2);
+    return EptHookMonitorFromVmxRoot(&g_GuestState[CoreId], MemoryAddressDetails);
 }
 
 /**

--- a/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hprdbghv/code/vmm/ept/Ept.c
@@ -843,13 +843,13 @@ EptHandlePageHookExit(VIRTUAL_MACHINE_STATE *              VCpu,
                       VMX_EXIT_QUALIFICATION_EPT_VIOLATION ViolationQualification,
                       UINT64                               GuestPhysicalAddr)
 {
-    BOOLEAN ResultOfHandlingHook;
-    BOOLEAN IsHandled;
-    BOOLEAN IgnoreReadOrWriteOrExec = FALSE;
-    BOOLEAN IsExecViolation         = FALSE;
     PVOID   TargetPage;
     UINT64  CurrentRip;
     UINT32  CurrentInstructionLength;
+    BOOLEAN IsHandled;
+    BOOLEAN ResultOfHandlingHook    = FALSE;
+    BOOLEAN IgnoreReadOrWriteOrExec = FALSE;
+    BOOLEAN IsExecViolation         = FALSE;
 
     LIST_FOR_EACH_LINK(g_EptState->HookedPagesList, EPT_HOOKED_PAGE_DETAIL, PageHookList, HookedEntry)
     {
@@ -865,13 +865,33 @@ EptHandlePageHookExit(VIRTUAL_MACHINE_STATE *              VCpu,
             // by setting the Monitor Trap Flag. Return false means that nothing special
             // for the caller to do
             //
-            ResultOfHandlingHook = EptHookHandleHookedPage(VCpu,
-                                                           HookedEntry,
-                                                           ViolationQualification,
-                                                           GuestPhysicalAddr,
-                                                           &HookedEntry->LastContextState,
-                                                           &IgnoreReadOrWriteOrExec,
-                                                           &IsExecViolation);
+
+            //
+            // Reaching here means that the hooks was actually caused VM-exit because of
+            // our configurations, but here we double whether the hook needs to trigger
+            // any event or not becuase the hooking address (physical) might not be in the
+            // target range. For example we might hook 0x123b000 to 0x123b300 but the hook
+            // happens on 0x123b4600, so we perform the necessary checks here
+            //
+
+            if (GuestPhysicalAddr >= HookedEntry->StartOfTargetPhysicalAddress && GuestPhysicalAddr <= HookedEntry->EndOfTargetPhysicalAddress)
+            {
+                ResultOfHandlingHook = EptHookHandleHookedPage(VCpu,
+                                                               HookedEntry,
+                                                               ViolationQualification,
+                                                               GuestPhysicalAddr,
+                                                               &HookedEntry->LastContextState,
+                                                               &IgnoreReadOrWriteOrExec,
+                                                               &IsExecViolation);
+            }
+            else
+            {
+                //
+                // Here we assume the hook is handled as the hook needs to be
+                // restored (just not within the range)
+                //
+                ResultOfHandlingHook = TRUE;
+            }
 
             if (ResultOfHandlingHook)
             {

--- a/hyperdbg/hprdbghv/code/vmm/vmx/Vmcall.c
+++ b/hyperdbg/hprdbghv/code/vmm/vmx/Vmcall.c
@@ -143,7 +143,7 @@ VmxVmcallHandler(VIRTUAL_MACHINE_STATE * VCpu,
     //
     if (VmcallNumber > TOP_LEVEL_DRIVERS_VMCALL_STARTING_NUMBER && VmcallNumber <= TOP_LEVEL_DRIVERS_VMCALL_ENDING_NUMBER)
     {
-        if (VmmCallbackVmcallHandler(VCpu->CoreId, VmcallNumber & 0xffffffff, OptionalParam1, OptionalParam2, OptionalParam3))
+        if (VmmCallbackVmcallHandler(VCpu->CoreId, VmcallNumber, OptionalParam1, OptionalParam2, OptionalParam3))
         {
             return STATUS_SUCCESS;
         }
@@ -156,7 +156,7 @@ VmxVmcallHandler(VIRTUAL_MACHINE_STATE * VCpu,
     //
     // Only 32bit of Vmcall is valid, this way we can use the upper 32 bit of the Vmcall
     //
-    switch (VmcallNumber & 0xffffffff)
+    switch (VmcallNumber)
     {
     case VMCALL_TEST:
     {
@@ -172,32 +172,13 @@ VmxVmcallHandler(VIRTUAL_MACHINE_STATE * VCpu,
     }
     case VMCALL_CHANGE_PAGE_ATTRIB:
     {
-        //
-        // Mask is the upper 32 bits to this Vmcall
-        // Upper 32 bits of the Vmcall contains the attribute mask
-        //
-        UINT32  AttributeMask        = (UINT32)((VmcallNumber & 0xFFFFFFFF00000000LL) >> 32);
-        BOOLEAN HookResult           = FALSE;
-        BOOLEAN UnsetExec            = FALSE;
-        BOOLEAN UnsetExecHiddenHook2 = FALSE;
-        BOOLEAN UnsetRead            = FALSE;
-        BOOLEAN UnsetWrite           = FALSE;
+        BOOLEAN  HookResult = FALSE;
+        CR3_TYPE ProcCr3    = {.Flags = OptionalParam3};
 
-        UnsetRead            = (AttributeMask & PAGE_ATTRIB_READ) ? TRUE : FALSE;
-        UnsetWrite           = (AttributeMask & PAGE_ATTRIB_WRITE) ? TRUE : FALSE;
-        UnsetExec            = (AttributeMask & PAGE_ATTRIB_EXEC) ? TRUE : FALSE;
-        UnsetExecHiddenHook2 = (AttributeMask & PAGE_ATTRIB_EXEC_HIDDEN_HOOK) ? TRUE : FALSE;
-
-        CR3_TYPE ProcCr3 = {.Flags = OptionalParam3};
-
-        HookResult = EptHookPerformPageHook2(VCpu,
-                                             OptionalParam1 /* TargetAddress */,
-                                             OptionalParam2 /* Hook Function*/,
-                                             ProcCr3 /* Process cr3 */,
-                                             UnsetRead,
-                                             UnsetWrite,
-                                             UnsetExec,
-                                             UnsetExecHiddenHook2);
+        HookResult = EptHookPerformPageHookMonitorAndInlineHook(VCpu,
+                                                                OptionalParam1 /* hook details */,
+                                                                ProcCr3 /* Process cr3 */,
+                                                                OptionalParam2 /* PageHookMask */);
 
         VmcallStatus = (HookResult == TRUE) ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL;
 

--- a/hyperdbg/hprdbghv/header/common/State.h
+++ b/hyperdbg/hprdbghv/header/common/State.h
@@ -187,6 +187,21 @@ typedef struct _EPT_HOOKED_PAGE_DETAIL
     SIZE_T PhysicalBaseAddress;
 
     /**
+     * @brief Start address of the target physical address.
+     */
+    SIZE_T StartOfTargetPhysicalAddress;
+
+    /**
+     * @brief End address of the target physical address.
+     */
+    SIZE_T EndOfTargetPhysicalAddress;
+
+    /**
+     * @brief Tag used for notifying the caller.
+     */
+    UINT64 HookingTag;
+
+    /**
      * @brief The base address of the page with fake contents. Used to swap page with fake contents
      * when a hook is hit.
      */

--- a/hyperdbg/hprdbghv/header/hooks/Hooks.h
+++ b/hyperdbg/hprdbghv/header/hooks/Hooks.h
@@ -191,24 +191,16 @@ EptHookPerformPageHook(VIRTUAL_MACHINE_STATE * VCpu, PVOID TargetAddress, CR3_TY
  * (A pre-allocated buffer should be available)
  *
  * @param VCpu
- * @param TargetAddress
- * @param HookFunction
+ * @param HookingDetails
  * @param ProcessCr3
- * @param UnsetRead
- * @param UnsetWrite
- * @param EptHiddenHook
- * @param UnsetExecute
+ * @param PageHookMask
  * @return BOOLEAN
  */
 BOOLEAN
-EptHookPerformPageHook2(VIRTUAL_MACHINE_STATE * VCpu,
-                        PVOID                   TargetAddress,
-                        PVOID                   HookFunction,
-                        CR3_TYPE                ProcessCr3,
-                        BOOLEAN                 UnsetRead,
-                        BOOLEAN                 UnsetWrite,
-                        BOOLEAN                 UnsetExecute,
-                        BOOLEAN                 EptHiddenHook);
+EptHookPerformPageHookMonitorAndInlineHook(VIRTUAL_MACHINE_STATE * VCpu,
+                                           PVOID                   HookingDetails,
+                                           CR3_TYPE                ProcessCr3,
+                                           UINT32                  PageHookMask);
 
 /**
  * @brief Hook in VMX non-root Mode (hidden breakpoint)
@@ -238,22 +230,29 @@ EptHookFromVmxRoot(PVOID TargetAddress);
  * @param TargetAddress
  * @param HookFunction
  * @param ProcessId
- * @param SetHookForRead
- * @param SetHookForWrite
- * @param SetHookForExec
- * @param EptHiddenHook2
  *
  * @return BOOLEAN
  */
 BOOLEAN
-EptHook2(VIRTUAL_MACHINE_STATE * VCpu,
-         PVOID                   TargetAddress,
-         PVOID                   HookFunction,
-         UINT32                  ProcessId,
-         BOOLEAN                 SetHookForRead,
-         BOOLEAN                 SetHookForWrite,
-         BOOLEAN                 SetHookForExec,
-         BOOLEAN                 EptHiddenHook2);
+EptHookInlineHook(VIRTUAL_MACHINE_STATE * VCpu,
+                  PVOID                   TargetAddress,
+                  PVOID                   HookFunction,
+                  UINT32                  ProcessId);
+
+/**
+ * @brief This function applies monitor hooks to the target EPT table
+ * @details this function should be called from VMX non-root mode
+ *
+ * @param VCpu
+ * @param HookingDetails
+ * @param ProcessId
+ *
+ * @return BOOLEAN
+ */
+BOOLEAN
+EptHookMonitorHook(VIRTUAL_MACHINE_STATE *                        VCpu,
+                   EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * HookingDetails,
+                   UINT32                                         ProcessId);
 
 /**
  * @brief Hook in VMX root-mode (hidden detours)
@@ -261,21 +260,26 @@ EptHook2(VIRTUAL_MACHINE_STATE * VCpu,
  * @param VCpu
  * @param TargetAddress
  * @param HookFunction
- * @param SetHookForRead
- * @param SetHookForWrite
- * @param SetHookForExec
- * @param EptHiddenHook2
  *
  * @return BOOLEAN
  */
 BOOLEAN
-EptHook2FromVmxRoot(VIRTUAL_MACHINE_STATE * VCpu,
-                    PVOID                   TargetAddress,
-                    PVOID                   HookFunction,
-                    BOOLEAN                 SetHookForRead,
-                    BOOLEAN                 SetHookForWrite,
-                    BOOLEAN                 SetHookForExec,
-                    BOOLEAN                 EptHiddenHook2);
+EptHookInlineHookFromVmxRoot(VIRTUAL_MACHINE_STATE * VCpu,
+                             PVOID                   TargetAddress,
+                             PVOID                   HookFunction);
+
+/**
+ * @brief This function applies EPT monitor hooks to the target EPT table
+ * @details this function should be called from VMX root-mode
+ *
+ * @param VCpu
+ * @param MemoryAddressDetails
+ *
+ * @return BOOLEAN
+ */
+BOOLEAN
+EptHookMonitorFromVmxRoot(VIRTUAL_MACHINE_STATE *                        VCpu,
+                          EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * MemoryAddressDetails);
 
 /**
  * @brief Handle hooked pages in Vmx-root mode

--- a/hyperdbg/hprdbgkd/code/debugger/core/Debugger.c
+++ b/hyperdbg/hprdbgkd/code/debugger/core/Debugger.c
@@ -1076,6 +1076,7 @@ DebuggerTriggerEvents(VMM_EVENT_TYPE_ENUM                   EventType,
 {
     DebuggerCheckForCondition *      ConditionFunc;
     DEBUGGER_TRIGGERED_EVENT_DETAILS EventTriggerDetail;
+    PEPT_HOOKS_CONTEXT               EptContext;
     PLIST_ENTRY                      TempList  = 0;
     PLIST_ENTRY                      TempList2 = 0;
     PROCESSOR_DEBUGGING_STATE *      DbgState  = NULL;
@@ -1184,11 +1185,15 @@ DebuggerTriggerEvents(VMM_EVENT_TYPE_ENUM                   EventType,
             // we get the events for all hidden hooks in a page granularity
             //
 
+            EptContext = (PEPT_HOOKS_CONTEXT)Context;
+
             //
-            // Context should be checked in physical address
+            // Context should be checked with hooking tag
+            // The hooking tag is same as the event tag if both
+            // of them match together
             //
-            if (!(((PEPT_HOOKS_CONTEXT)(Context))->PhysicalAddress >= CurrentEvent->Options.OptionalParam1 &&
-                  ((PEPT_HOOKS_CONTEXT)(Context))->PhysicalAddress < CurrentEvent->Options.OptionalParam2))
+
+            if (EptContext->HookingTag != CurrentEvent->Tag)
             {
                 //
                 // The value is not withing our expected range
@@ -1200,7 +1205,7 @@ DebuggerTriggerEvents(VMM_EVENT_TYPE_ENUM                   EventType,
                 //
                 // Fix the context to virtual address
                 //
-                Context = ((PEPT_HOOKS_CONTEXT)(Context))->VirtualAddress;
+                Context = EptContext->VirtualAddress;
             }
 
             break;

--- a/hyperdbg/hprdbgkd/code/debugger/events/DebuggerEvents.c
+++ b/hyperdbg/hprdbgkd/code/debugger/events/DebuggerEvents.c
@@ -56,30 +56,23 @@ DebuggerEventDisableMovToCr3ExitingOnAllProcessors()
 }
 
 /**
- * @brief Event for address, we don't use address range here,
- * address ranges should be check in event section
+ * @brief Apply monitor ept hook events for address
  *
- * @param Address
+ * @param HookingDetails
  * @param ProcessId
- * @param EnableForRead
- * @param EnableForWrite
- * @param EnableForExecute
  * @param ApplyDirectlyFromVmxRoot
  *
  * @return VOID
  */
 BOOLEAN
-DebuggerEventEnableMonitorReadWriteExec(UINT64  Address,
-                                        UINT32  ProcessId,
-                                        BOOLEAN EnableForRead,
-                                        BOOLEAN EnableForWrite,
-                                        BOOLEAN EnableForExecute,
-                                        BOOLEAN ApplyDirectlyFromVmxRoot)
+DebuggerEventEnableMonitorReadWriteExec(EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * HookingDetails,
+                                        UINT32                                         ProcessId,
+                                        BOOLEAN                                        ApplyDirectlyFromVmxRoot)
 {
     //
     // Check if the detail is ok for either read or write or both
     //
-    if (!EnableForRead && !EnableForWrite && !EnableForExecute)
+    if (!HookingDetails->SetHookForRead && !HookingDetails->SetHookForWrite && !HookingDetails->SetHookForExec)
     {
         return FALSE;
     }
@@ -89,9 +82,9 @@ DebuggerEventEnableMonitorReadWriteExec(UINT64  Address,
     // such a thing, we will enable the Read silently here if, this problem will be
     // solved when the trigger works, the trigger routines won't enable reads
     //
-    if (EnableForWrite)
+    if (HookingDetails->SetHookForWrite)
     {
-        EnableForRead = TRUE;
+        HookingDetails->SetHookForRead = TRUE;
     }
 
     //
@@ -99,24 +92,14 @@ DebuggerEventEnableMonitorReadWriteExec(UINT64  Address,
     //
     if (ApplyDirectlyFromVmxRoot)
     {
-        return ConfigureEptHook2FromVmxRoot(KeGetCurrentProcessorNumberEx(NULL),
-                                            Address,
-                                            NULL,
-                                            EnableForRead,
-                                            EnableForWrite,
-                                            EnableForExecute,
-                                            FALSE);
+        return ConfigureEptHookMonitorFromVmxRoot(KeGetCurrentProcessorNumberEx(NULL),
+                                                  HookingDetails);
     }
     else
     {
-        return ConfigureEptHook2(KeGetCurrentProcessorNumberEx(NULL),
-                                 Address,
-                                 NULL,
-                                 ProcessId,
-                                 EnableForRead,
-                                 EnableForWrite,
-                                 EnableForExecute,
-                                 FALSE);
+        return ConfigureEptHookMonitor(KeGetCurrentProcessorNumberEx(NULL),
+                                       HookingDetails,
+                                       ProcessId);
     }
 }
 

--- a/hyperdbg/hprdbgkd/code/debugger/events/Termination.c
+++ b/hyperdbg/hprdbgkd/code/debugger/events/Termination.c
@@ -107,11 +107,16 @@ TerminateExternalInterruptEvent(PDEBUGGER_EVENT Event, BOOLEAN InputFromVmxRoot)
 VOID
 TerminateHiddenHookReadAndWriteAndExecuteEvent(PDEBUGGER_EVENT Event, BOOLEAN InputFromVmxRoot)
 {
+    UINT64 RemainingSize;
     UINT64 PagesBytes;
-    UINT64 TempOptionalParam1;
+    UINT64 ConstEndAddress;
+    UINT64 TempNextPageAddr;
+    UINT64 TempStartAddress = Event->Options.OptionalParam3;
+    UINT64 TempEndAddress   = Event->Options.OptionalParam4;
+    ConstEndAddress         = TempEndAddress;
 
     //
-    // Because there are different EPT hooks, like READ, WRITE, READ WRITE,
+    // Because there are different EPT hooks, like READ, WRITE, EXECUTE,
     // DETOURS INLINE HOOK, HIDDEN BREAKPOINT HOOK and all of them are
     // unhooked with a same routine, we will not check whther the list of
     // all of them is empty or not and instead, we remove just a single
@@ -120,24 +125,63 @@ TerminateHiddenHookReadAndWriteAndExecuteEvent(PDEBUGGER_EVENT Event, BOOLEAN In
     // then it won't cause any problem for other hooks
     //
 
-    TempOptionalParam1 = Event->Options.OptionalParam3;
+    PagesBytes = (UINT64)PAGE_ALIGN(TempStartAddress);
+    PagesBytes = TempEndAddress - PagesBytes;
+    PagesBytes = PagesBytes / PAGE_SIZE;
 
-    PagesBytes = PAGE_ALIGN(TempOptionalParam1);
-    PagesBytes = Event->Options.OptionalParam4 - PagesBytes;
+    RemainingSize = TempEndAddress - TempStartAddress;
 
-    for (size_t i = 0; i <= PagesBytes / PAGE_SIZE; i++)
+    // LogInfo("Monitor termination, Start address: %llx, end address: %llx\n\n\n",
+    //         TempStartAddress,
+    //         TempEndAddress,
+    //         RemainingSize);
+
+    for (size_t i = 0; i <= PagesBytes; i++)
     {
+        if (RemainingSize >= PAGE_SIZE)
+        {
+            TempEndAddress = (TempStartAddress + ((UINT64)PAGE_ALIGN(TempStartAddress + PAGE_SIZE) - TempStartAddress)) - 1;
+            RemainingSize  = ConstEndAddress - TempEndAddress - 1;
+        }
+        else
+        {
+            TempNextPageAddr = (UINT64)PAGE_ALIGN(TempStartAddress + RemainingSize);
+
+            //
+            // Check if by adding the remaining size, we'll go to the next
+            // page boundary or not
+            //
+            if (TempNextPageAddr > ((UINT64)PAGE_ALIGN(TempStartAddress)))
+            {
+                //
+                // It goes to the next page boundary
+                //
+                TempEndAddress = TempNextPageAddr - 1;
+                RemainingSize  = RemainingSize - (TempEndAddress - TempStartAddress) - 1;
+            }
+            else
+            {
+                TempEndAddress = TempStartAddress + RemainingSize;
+                RemainingSize  = 0;
+            }
+        }
+
         if (InputFromVmxRoot)
         {
-            TerminateEptHookUnHookSingleAddressFromVmxRootAndApplyInvalidation((UINT64)TempOptionalParam1 + (i * PAGE_SIZE),
+            TerminateEptHookUnHookSingleAddressFromVmxRootAndApplyInvalidation((UINT64)TempStartAddress,
                                                                                NULL);
         }
         else
         {
-            ConfigureEptHookUnHookSingleAddress((UINT64)TempOptionalParam1 + (i * PAGE_SIZE),
+            ConfigureEptHookUnHookSingleAddress((UINT64)TempStartAddress,
                                                 NULL,
                                                 Event->ProcessId);
         }
+
+        //
+        // Swap the temporary start address and temporary end address
+        //
+        TempStartAddress = TempEndAddress + 1;
     }
 }
 

--- a/hyperdbg/hprdbgkd/header/debugger/events/DebuggerEvents.h
+++ b/hyperdbg/hprdbgkd/header/debugger/events/DebuggerEvents.h
@@ -28,12 +28,9 @@ VOID
 DebuggerEventDisableMovToCr3ExitingOnAllProcessors();
 
 BOOLEAN
-DebuggerEventEnableMonitorReadWriteExec(UINT64  Address,
-                                        UINT32  ProcessId,
-                                        BOOLEAN EnableForRead,
-                                        BOOLEAN EnableForWrite,
-                                        BOOLEAN EnableForExecute,
-                                        BOOLEAN ApplyDirectlyFromVmxRoot);
+DebuggerEventEnableMonitorReadWriteExec(EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * HookingDetails,
+                                        UINT32                                         ProcessId,
+                                        BOOLEAN                                        ApplyDirectlyFromVmxRoot);
 
 BOOLEAN
 DebuggerCheckProcessOrThreadChange(_In_ UINT32 CoreId);

--- a/hyperdbg/include/SDK/Headers/Constants.h
+++ b/hyperdbg/include/SDK/Headers/Constants.h
@@ -18,7 +18,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 8
-#define VERSION_PATCH 0
+#define VERSION_PATCH 1
 
 //
 // Example of __DATE__ string: "Jul 27 2012"

--- a/hyperdbg/include/SDK/Headers/DataTypes.h
+++ b/hyperdbg/include/SDK/Headers/DataTypes.h
@@ -308,9 +308,36 @@ typedef struct _DIRECT_VMCALL_PARAMETERS
  */
 typedef struct _EPT_HOOKS_CONTEXT
 {
+    UINT64 HookingTag; // This is same as the event tag
     UINT64 PhysicalAddress;
     UINT64 VirtualAddress;
 } EPT_HOOKS_CONTEXT, *PEPT_HOOKS_CONTEXT;
+
+/**
+ * @brief Setting details for EPT Hooks (!monitor)
+ *
+ */
+typedef struct _EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR
+{
+    UINT64  StartAddress;
+    UINT64  EndAddress;
+    BOOLEAN SetHookForRead;
+    BOOLEAN SetHookForWrite;
+    BOOLEAN SetHookForExec;
+    UINT64  Tag;
+
+} EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR, *PEPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR;
+
+/**
+ * @brief Setting details for EPT Hooks (!epthook2)
+ *
+ */
+typedef struct _EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2
+{
+    PVOID TargetAddress;
+    PVOID HookFunction;
+
+} EPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2, *PEPT_HOOKS_ADDRESS_DETAILS_FOR_EPTHOOK2;
 
 /**
  * @brief Details of unhooking single EPT hooks

--- a/hyperdbg/include/SDK/Imports/HyperDbgVmmImports.h
+++ b/hyperdbg/include/SDK/Imports/HyperDbgVmmImports.h
@@ -280,23 +280,24 @@ IMPORT_EXPORT_VMM BOOLEAN
 ConfigureEptHookFromVmxRoot(PVOID TargetAddress);
 
 IMPORT_EXPORT_VMM BOOLEAN
-ConfigureEptHook2(UINT32  CoreId,
-                  PVOID   TargetAddress,
-                  PVOID   HookFunction,
-                  UINT32  ProcessId,
-                  BOOLEAN SetHookForRead,
-                  BOOLEAN SetHookForWrite,
-                  BOOLEAN SetHookForExec,
-                  BOOLEAN EptHiddenHook2);
+ConfigureEptHook2(UINT32 CoreId,
+                  PVOID  TargetAddress,
+                  PVOID  HookFunction,
+                  UINT32 ProcessId);
 
 IMPORT_EXPORT_VMM BOOLEAN
-ConfigureEptHook2FromVmxRoot(UINT32  CoreId,
-                             PVOID   TargetAddress,
-                             PVOID   HookFunction,
-                             BOOLEAN SetHookForRead,
-                             BOOLEAN SetHookForWrite,
-                             BOOLEAN SetHookForExec,
-                             BOOLEAN EptHiddenHook2);
+ConfigureEptHook2FromVmxRoot(UINT32 CoreId,
+                             PVOID  TargetAddress,
+                             PVOID  HookFunction);
+
+IMPORT_EXPORT_VMM BOOLEAN
+ConfigureEptHookMonitor(UINT32                                         CoreId,
+                        EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * HookingDetails,
+                        UINT32                                         ProcessId);
+
+IMPORT_EXPORT_VMM BOOLEAN
+ConfigureEptHookMonitorFromVmxRoot(UINT32                                         CoreId,
+                                   EPT_HOOKS_ADDRESS_DETAILS_FOR_MEMORY_MONITOR * MemoryAddressDetails);
 
 IMPORT_EXPORT_VMM BOOLEAN
 ConfigureEptHookModifyInstructionFetchState(UINT32  CoreId,


### PR DESCRIPTION
## [0.8.1.0] - 2024-02-01
New release of the HyperDbg Debugger.

### Changed
- Fix the issue of not intercepting memory monitoring on non-contiguous physical memory allocations
- The speed of memory read/write/execution interception is enhanced by avoiding triggering out-of-range events

### Added
- The **!monitor** command now supports length in parameters ([link](https://docs.hyperdbg.org/commands/extension-commands/monitor#syntax))