### PR TITLE
fix wcsncmp in script-engine

### DIFF
--- a/hyperdbg/script-engine/python/Boolean_Expression_Grammar.txt
+++ b/hyperdbg/script-engine/python/Boolean_Expression_Grammar.txt
@@ -14,13 +14,16 @@
 .TwoOpFunc3->strcmp
 
 # ThreeOpFunc3 the first two inputs are numbers or strings and the third input is a number and returns a number.
-.ThreeOpFunc3->memcmp strncmp wcsncmp
+.ThreeOpFunc3->memcmp strncmp
 
 # OneOpFunc4 input is a number or a wstring and returns a number.
 .OneOpFunc4->wcslen
 
 # TwoOpFunc4 the two inputs are numbers or wstrings and returns a number.
 .TwoOpFunc4->wcscmp
+
+# ThreeOpFunc4 the first two inputs are numbers or wstrings and the third input is a number and returns a number.
+.ThreeOpFunc4->wcsncmp
 
 .OperatorsOneOperand->inc dec reference dereference
 
@@ -88,6 +91,7 @@ E12->.TwoOpFunc3 ( StringNumber , StringNumber ) @.TwoOpFunc3
 E12->.ThreeOpFunc3 ( StringNumber , StringNumber , EXP ) @.ThreeOpFunc3
 E12->.OneOpFunc4 ( WstringNumber ) @.OneOpFunc4
 E12->.TwoOpFunc4 ( WstringNumber , WstringNumber ) @.TwoOpFunc4
+E12->.ThreeOpFunc4 ( WstringNumber , WstringNumber , EXP ) @.ThreeOpFunc4
 
 E12->( BE )
 

--- a/hyperdbg/script-engine/python/Grammar.txt
+++ b/hyperdbg/script-engine/python/Grammar.txt
@@ -23,7 +23,10 @@
 .TwoOpFunc3->strcmp
 
 # ThreeOpFunc3 the first two inputs are numbers or strings and the third input is a number and returns a number.
-.ThreeOpFunc3->memcmp strncmp wcsncmp
+.ThreeOpFunc3->memcmp strncmp
+
+# ThreeOpFunc4 the first two inputs are numbers or wstrings and the third input is a number and returns a number.
+.ThreeOpFunc4->wcsncmp
 
 # OneOpFunc4 input is a number or a wstring and returns a number.
 .OneOpFunc4->wcslen
@@ -117,6 +120,7 @@ CALL_FUNC_STATEMENT->.ThreeOpFunc3 ( StringNumber , StringNumber , EXPRESSION @.
 CALL_FUNC_STATEMENT->.OneOpFunc4 ( WstringNumber @.OneOpFunc4 ) @IGNORE_LVALUE
 CALL_FUNC_STATEMENT->.TwoOpFunc4 ( WstringNumber , WstringNumber @.TwoOpFunc4 ) @IGNORE_LVALUE
 CALL_FUNC_STATEMENT->.ThreeOpFunc2 ( EXPRESSION , EXPRESSION , EXPRESSION @.ThreeOpFunc2 )
+CALL_FUNC_STATEMENT->.ThreeOpFunc4 ( WstringNumber , WstringNumber , EXPRESSION @.ThreeOpFunc4 ) @IGNORE_LVALUE
 
 VA->, EXPRESSION VA
 VA->eps
@@ -194,6 +198,7 @@ E12->.TwoOpFunc3 ( StringNumber , StringNumber @.TwoOpFunc3 )
 E12->.ThreeOpFunc3 ( StringNumber , StringNumber , EXPRESSION @.ThreeOpFunc3 )
 E12->.OneOpFunc4 ( WstringNumber @.OneOpFunc4 )
 E12->.TwoOpFunc4 ( WstringNumber , WstringNumber @.TwoOpFunc4 )
+E12->.ThreeOpFunc4 ( WstringNumber , WstringNumber , EXPRESSION @.ThreeOpFunc4 )
 
 E12->( EXPRESSION )
 


### PR DESCRIPTION
# Description

https://github.com/HyperDbg/HyperDbg/issues/373

![image](https://github.com/HyperDbg/HyperDbg/assets/54590608/03b83396-f409-4d39-a467-6bff47f733e1)

![image](https://github.com/HyperDbg/HyperDbg/assets/54590608/ed9b7296-80ae-4d05-ad13-82513ce81fde)

The parsr would parse space as token.

BTW, I recently finish my compiler couerse, and learn a lot about compiler knowledge, so I believe there are a lot of things we can modify and improve for the parser, like it is better that not define the grammer for each different functions , this way would make more complited to define new functions .