### PR TITLE
add stack buffer in vmx-root

### DIFF
--- a/hyperdbg/hprdbgctrl/code/debugger/script-engine/script-engine-wrapper.cpp
+++ b/hyperdbg/hprdbgctrl/code/debugger/script-engine/script-engine-wrapper.cpp
@@ -390,10 +390,36 @@ ScriptEngineEvalWrapper(PGUEST_REGS GuestRegs,
     //
     // Making symbol buffer
     //
-    PSYMBOL_BUFFER StackBuffer       = GetStackBuffer();
-    int            StackIndx         = 0;
-    int            StackBaseIndx     = 0;
-    int            StackTempBaseIndx = 0;
+
+    PSYMBOL_BUFFER StackBuffer = (PSYMBOL_BUFFER)malloc(sizeof(SYMBOL_BUFFER));
+    if (StackBuffer == NULL)
+    {
+        free(g_ScriptGlobalVariables);
+        free(g_ScriptLocalVariables);
+
+        ShowMessages("err, could not allocate memory for user-mode stack buffer");
+
+        return;
+    }
+    StackBuffer->Pointer = 0;
+    StackBuffer->Size    = 0;
+    StackBuffer->Message = NULL;
+    StackBuffer->Head    = (PSYMBOL)malloc(MAX_STACK_BUFFER_COUNT * sizeof(SYMBOL));
+    if (StackBuffer->Head == NULL)
+    {
+        free(g_ScriptGlobalVariables);
+        free(g_ScriptLocalVariables);
+        free(StackBuffer);
+        ShowMessages("err, could not allocate memory for user-mode stack buffer");
+
+        return;
+    }
+    RtlZeroMemory(StackBuffer->Head, MAX_STACK_BUFFER_COUNT * sizeof(SYMBOL));
+
+
+    int StackIndx         = 0;
+    int StackBaseIndx     = 0;
+    int StackTempBaseIndx = 0;
 
     if (CodeBuffer->Message == NULL)
     {

--- a/hyperdbg/hprdbgkd/header/debugger/core/State.h
+++ b/hyperdbg/hprdbgkd/header/debugger/core/State.h
@@ -170,6 +170,7 @@ typedef struct _PROCESSOR_DEBUGGING_STATE
     UINT64                                     HardwareDebugRegisterForStepping;
     UINT64 *                                   ScriptEngineCoreSpecificLocalVariable;
     UINT64 *                                   ScriptEngineCoreSpecificTempVariable;
+    UINT64 *                                   ScriptEngineCoreSpecificStackBuffer;
     PKDPC                                      KdDpcObject;                       // DPC object to be used in kernel debugger
     CHAR                                       KdRecvBuffer[MaxSerialPacketSize]; // Used for debugging buffers (receiving buffers from serial devices)
 

--- a/hyperdbg/include/SDK/Headers/Constants.h
+++ b/hyperdbg/include/SDK/Headers/Constants.h
@@ -625,6 +625,8 @@ const unsigned char BuildSignature[] = {
 
 #define MAX_TEMP_COUNT 128
 
+#define MAX_STACK_BUFFER_COUNT 128
+
 // TODO: Extract number of variables from input of ScriptEngine
 // and allocate variableList Dynamically.
 #define MAX_VAR_COUNT 512

--- a/hyperdbg/include/SDK/Imports/HyperDbgScriptImports.h
+++ b/hyperdbg/include/SDK/Imports/HyperDbgScriptImports.h
@@ -19,7 +19,6 @@ extern "C" {
 #endif
 
 __declspec(dllimport) PSYMBOL_BUFFER ScriptEngineParse(char * str);
-__declspec(dllimport) PSYMBOL_BUFFER GetStackBuffer();
 __declspec(dllimport) void PrintSymbolBuffer(const PSYMBOL_BUFFER SymbolBuffer);
 __declspec(dllimport) void PrintSymbol(PSYMBOL Symbol);
 __declspec(dllimport) void RemoveSymbolBuffer(PSYMBOL_BUFFER SymbolBuffer);

--- a/hyperdbg/script-engine/code/script-engine.c
+++ b/hyperdbg/script-engine/code/script-engine.c
@@ -3113,14 +3113,3 @@ LalrIsOperandType(PTOKEN Token)
     }
     return FALSE;
 }
-
-PSYMBOL_BUFFER
-GetStackBuffer()
-{
-    PSYMBOL_BUFFER StackBuffer = NewSymbolBuffer();
-    for (int i = 0; i < 128; i++)
-    {
-        PushSymbol(StackBuffer, NewSymbol());
-    }
-    return StackBuffer;
-}

--- a/hyperdbg/script-engine/header/script-engine.h
+++ b/hyperdbg/script-engine/header/script-engine.h
@@ -100,7 +100,6 @@ PSYMBOL
 ToSymbol(PTOKEN PTOKEN, PSCRIPT_ENGINE_ERROR_TYPE Error);
 
 __declspec(dllexport) PSYMBOL_BUFFER ScriptEngineParse(char * str);
-__declspec(dllexport) PSYMBOL_BUFFER GetStackBuffer();
 
 void
 ScriptEngineBooleanExpresssionParse(


### PR DESCRIPTION
# Description

Add stack buffer in vmx-root, so now we can use user-defined functions in script-engine.

![image](https://github.com/HyperDbg/HyperDbg/assets/54590608/15e73b00-f4e3-46fa-8eba-217042fe18d4)

Each core runs script at one time, and two or more cores run different scripts at the same time, so each core has its own stack buffer. I follow `ScriptEngineCoreSpecificTempVariable` to allocate  memory to `ScriptEngineCoreSpecificStackBuffer`. 

Not really sure if I did it the right way, so it should be check.
