### PR TITLE
improved: asm parse - symbol parse - byte gen only

### DIFF
--- a/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/a.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/a.cpp
@@ -1,35 +1,141 @@
+
 /**
- * @file a.cpp
- * @author Abbas Masoumi
- * @brief a command
+ * @file e.cpp
+ * @author Abbas Masoumi Gorji
+ * @brief e* command
  * @details
- * @version 0.10
- * @date 2024-07-14
+ * @version 0.1
+ * @date 2024-07-15
  *
  * @copyright This project is released under the GNU Public License v3.
  *
  */
 #include "pch.h"
+#include "keystone\keystone.h"
 
 extern BOOLEAN                  g_IsSerialConnectedToRemoteDebuggee;
 extern ACTIVE_DEBUGGING_PROCESS g_ActiveProcessDebuggingState;
 
-struct Instruction
-{
-    std::string              mnemonic;
-    std::vector<std::string> operands;
-};
-
 struct AssembleData
 {
-    std::string              AsmRaw {};
-    std::string              AsmFixed {};
-    std::vector<Instruction> instructions;
-    size_t                   StatementCount {};
-    size_t                   BytesCount {};
-    unsigned char *          EncodedBytes {};
-    vector<UINT64>           EncBytesIntVec {};
-    ks_err                   ks_err {};
+public:
+    std::string     AsmRaw {};
+    std::string     AsmFixed {};
+    size_t          StatementCount {};
+    size_t          BytesCount {};
+    unsigned char * EncodedBytes {};
+    vector<UINT64>  EncBytesIntVec {};
+    ks_err          ks_err {};
+
+    AssembleData() = default;
+
+    /**
+     * @brief tries to solve the symbol issue with Keystone, which apparently originates from LLVM-MC.
+     *
+     * @return VOID
+     */
+    void
+    parseAssemblyData()
+    {
+        std::string RawAsm = AsmRaw;
+
+        // remove all "\n" instances
+        RawAsm.erase(std::remove(RawAsm.begin(), RawAsm.end(), '\n'), RawAsm.end());
+
+        // remove multiple spaces
+        std::regex multipleSpaces(" +");
+        RawAsm = std::regex_replace(RawAsm, multipleSpaces, " ");
+
+        // split assembly line by ';'
+        std::vector<std::string> assemblyInstructions;
+        size_t                   pos       = 0;
+        std::string              delimiter = ";";
+        while ((pos = RawAsm.find(delimiter)) != std::string::npos)
+        {
+            std::string token = RawAsm.substr(0, pos);
+            if (!token.empty())
+            {
+                assemblyInstructions.push_back(token);
+            }
+            RawAsm.erase(0, pos + delimiter.length());
+        }
+        if (!RawAsm.empty())
+        {
+            assemblyInstructions.push_back(RawAsm);
+        }
+
+        // process each assembly instruction
+        for (auto & instructionLine : assemblyInstructions)
+        {
+            std::string expr {};
+            UINT64      expr_addr {};
+            size_t      start {};
+
+            while ((start = instructionLine.find('<', start)) != std::string::npos)
+            {
+                size_t end = instructionLine.find('>', start);
+                if (end != std::string::npos)
+                {
+                    std::string expr = instructionLine.substr(start + 1, end - start - 1);
+                    if (!SymbolConvertNameOrExprToAddress(expr, &expr_addr) && expr_addr == 0)
+                    {
+                        ShowMessages("err, failed to resolve the symbol [ %s ].\n", expr.c_str());
+                        start += expr.size() + 2;
+                        continue;
+                    }
+
+                    std::ostringstream oss;
+                    oss << std::hex << std::showbase << expr_addr;
+                    instructionLine.replace(start, end - start + 1, oss.str());
+                }
+                else
+                {
+                    // No matching '>' found, break the loop
+                    break;
+                }
+                start += expr.size() + 2;
+            }
+        }
+
+        // Append ";" between two std::strings
+        auto apndSemCln = [](std::string a, std::string b) {
+            return std::move(a) + ';' + std::move(b);
+        };
+        // Concatenate each assembly line
+        AsmFixed = std::accumulate(std::next(assemblyInstructions.begin()), assemblyInstructions.end(), assemblyInstructions.at(0), apndSemCln);
+
+        if (!AsmFixed.empty() && AsmFixed.back() == ';')
+        {
+            // remove the last ";" for it will be counted as a statement by Keystone and a wrong number would be printed
+            AsmFixed.pop_back();
+        }
+
+        while (!AsmFixed.empty() && AsmFixed.back() == ';')
+        {
+            AsmFixed.pop_back();
+        }
+    }
+};
+
+class _CMD
+{
+public:
+    std::string Command_str;
+    std::string Address_str;
+    std::string AsmSnippet;
+    std::string Start_Address_str;
+    std::string ProcId_str;
+
+    _CMD() = default;
+
+    bool isEmpty() const
+    {
+        return Command_str.empty() &&
+               Address_str.empty() &&
+               AsmSnippet.empty() &&
+               Start_Address_str.empty() &&
+               ProcId_str.empty();
+    }
 };
 
 /**
@@ -48,181 +154,108 @@ CommandAssembleHelp()
 
     ShowMessages("\n");
     ShowMessages("\t\te.g : a fffff8077356f010 {nop; nop; nop} \n");
-    ShowMessages("\t\te.g : a nt!ExAllocatePoolWithTag+10+@rcx {jmp nt!ExAllocatePoolWithTag+10} \n");
-    ShowMessages("\t\te.g : a nt!ExAllocatePoolWithTag {add DWORD PTR [nt!ExAllocatePoolWithTag+10+@rax], 99} \n");
-    ShowMessages("\t\te.g : !a abc01d {add DWORD PTR [nt!ExAllocatePoolWithTag+10+@rax], 99} \n");
+    ShowMessages("\t\te.g : a nt!ExAllocatePoolWithTag+10+@rcx {jmp <nt!ExAllocatePoolWithTag+10>} \n");
+    ShowMessages("\t\te.g : a nt!ExAllocatePoolWithTag {add DWORD PTR [<nt!ExAllocatePoolWithTag+10+@rax>], 99} \n");
+    ShowMessages("\t\t      note that within assembly snippet, symbols must be enclosed by \" <> \"\n");
+    ShowMessages("\t\t      note that type specifier must be capital\n");
+
+    ShowMessages("\n");
+    ShowMessages("\tto merely view the byte code of an assembly snippet:\n");
+    ShowMessages("\t\ta {jmp <nt!ExAllocatePoolWithTag+10>} [start_address]\n");
+    ShowMessages("\t\t\"start_address\" is useful when dealing with relative instructions like \" jmp \" ");
 }
 
-/**
- * @brief tries to solve the symbol issue with Keystone, which apparently originates from LLVM-MC.
- *
- * @return VOID
- */
-void
-parseAssemblyLine(AssembleData & assembleData)
-{
-    std::string RawAsm = assembleData.AsmRaw;
-    std::regex  instructionRegex(R"(\s*(\w+)\s+(.+))");
-    std::smatch match;
-
-    // split assembly line by ';'
-    std::vector<std::string> assemblyInstructions;
-    size_t                   pos       = 0;
-    std::string              delimiter = ";";
-    while ((pos = RawAsm.find(delimiter)) != std::string::npos)
-    {
-        std::string token = RawAsm.substr(0, pos);
-        if (!token.empty())
-        {
-            assemblyInstructions.push_back(token);
-        }
-        RawAsm.erase(0, pos + delimiter.length());
-    }
-    if (!RawAsm.empty())
-    {
-        assemblyInstructions.push_back(RawAsm);
-    }
-
-    // process each assembly instruction
-    for (const auto & instructionLine : assemblyInstructions)
-    {
-        if (std::regex_match(instructionLine, match, instructionRegex))
-        {
-            Instruction instr;
-            instr.mnemonic = match[1].str();
-
-            // split operands by ','
-            std::string operandStr = match[2].str();
-            size_t      start = 0, end = 0;
-            while ((end = operandStr.find(',', start)) != std::string::npos)
-            {
-                instr.operands.push_back(operandStr.substr(start, end - start));
-                start = end + 1;
-            }
-            instr.operands.push_back(operandStr.substr(start));
-
-            // remove '[' and ']' from operands if present
-            for (auto & operand : instr.operands)
-            {
-                // a simple check to see if we're dealing with symbols or not
-                bool containsExclamation = (operand.find('!') != std::string::npos);
-                bool containsAt          = (operand.find('@') != std::string::npos);
-
-                if (!containsExclamation && !containsAt)
-                {
-                    continue;
-                }
-
-                std::string expr;
-                UINT64      expr_addr;
-                // find '[' and ']' to replace their content
-                auto leftBracketPos  = operand.find('[');
-                auto rightBracketPos = operand.find(']');
-                if (leftBracketPos != std::string::npos && rightBracketPos != std::string::npos &&
-                    rightBracketPos > leftBracketPos + 1)
-                {
-                    expr = operand.substr(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1);
-
-                    if (!SymbolConvertNameOrExprToAddress(expr, &expr_addr))
-                    {
-                        // not resolved
-                        continue;
-                    }
-
-                    // replace symbol with its equivalent address
-                    std::ostringstream oss;
-                    oss << std::hex << std::showbase << expr_addr;
-                    operand.replace(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1, oss.str());
-                }
-                else
-                {
-                    expr = operand.substr(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1);
-
-                    if (!SymbolConvertNameOrExprToAddress(expr, &expr_addr))
-                    {
-                        // not resolved
-                        continue;
-                    }
-
-                    // replace symbol with its equivalent address
-                    std::ostringstream oss;
-                    oss << std::hex << std::showbase << expr_addr;
-                    operand.replace(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1, oss.str());
-                }
-            }
-
-            assembleData.instructions.push_back(instr);
-        }
-        else
-        {
-            // most probably a unary instruction
-            // std::cerr << "Error: Failed to parse instruction: " << instructionLine << std::endl;
-            Instruction instr;
-            instr.mnemonic = instructionLine;
-            assembleData.instructions.push_back(instr);
-        }
-    }
-
-    // serialize the fixed asm
-    std::ostringstream oss;
-    for (const auto & instr : assembleData.instructions)
-    {
-        oss << instr.mnemonic;
-        for (size_t i = 0; i < instr.operands.size(); ++i)
-        {
-            if (i == 0)
-            {
-                oss << " ";
-            }
-            else
-            {
-                oss << ",";
-            }
-            oss << instr.operands[i];
-        }
-        oss << ";";
-    }
-
-    assembleData.AsmFixed = oss.str();
-}
-
-std::vector<std::string>
+_CMD
 ParseUserCmd(const std::string & command)
 {
-    std::vector<std::string> result;
-    auto                     it  = command.begin();
-    auto                     end = command.end();
-    while (it != end)
+    std::vector<std::string> CmdVec;
+    _CMD                     CMD {};
+    _CMD                     CmdEmpty {};
+
+    auto Cmd_it  = command.begin();
+    auto Cmd_end = command.end();
+
+    while (Cmd_it != Cmd_end)
     {
         // skip leading whitespace
-        it = std::find_if_not(it, end, ::isspace);
-        if (it == end)
+        Cmd_it = std::find_if_not(Cmd_it, Cmd_end, ::isspace);
+        if (Cmd_it == Cmd_end)
             break;
-        if (*it == '{')
+        if (*Cmd_it == '{')
         {
             // find matching closing brace
-            auto closeIt = std::find(it + 1, end, '}');
-            if (closeIt != end)
+            auto closeIt = std::find(Cmd_it + 1, Cmd_end, '}');
+            if (closeIt != Cmd_end)
             {
-                std::string RawAsm(it + 1, closeIt); // remove "{}"
-                result.emplace_back(RawAsm);
-                it = closeIt + 1;
+                if (CmdVec.size() < 2)
+                {
+                    // if yes, asm snippet was provided right after "a" command (2nd index)
+                    // i.e. no address were provided to assembling to
+                    CmdVec.emplace_back(""); // emtpty addres string
+                }
+                std::string RawAsm(Cmd_it + 1, closeIt); // remove "{}"
+                CmdVec.emplace_back(RawAsm);
+                Cmd_it = closeIt + 1;
             }
             else
             {
                 // no matching brace
-                ShowMessages("Assembly snippet is not closed.");
+                ShowMessages("err, assembly snippet is not closed.");
             }
         }
         else
         {
             // normal text, find next space
-            auto spaceIt = std::find_if(it, end, ::isspace);
-            result.emplace_back(it, spaceIt);
-            it = spaceIt;
+            auto spaceIt = std::find_if(Cmd_it, Cmd_end, ::isspace);
+            CmdVec.emplace_back(Cmd_it, spaceIt);
+            Cmd_it = spaceIt;
         }
     }
-    return result;
+
+    // check if there is any "pid"
+    auto Pid_it = std::find_if(CmdVec.begin(), CmdVec.end(), [](const std::string & s) { return s.find("pid") != std::string::npos; });
+    if (Pid_it != CmdVec.end())
+    {
+        bool isLast       = (Pid_it == std::prev(CmdVec.end()));
+        bool isSecondLast = (Pid_it == std::prev(CmdVec.end(), 2));
+        if (!isLast && !isSecondLast)
+        {
+            ShowMessages("pid must be the last argument.");
+            return CmdEmpty;
+        }
+        if (g_IsSerialConnectedToRemoteDebuggee)
+        {
+            ShowMessages(ASSERT_MESSAGE_CANNOT_SPECIFY_PID);
+            return CmdEmpty;
+        }
+
+        if (std::next(Pid_it) != CmdVec.end()) // is there anything after "pid"?
+        {
+            CMD.ProcId_str = std::string(*(++Pid_it));
+        }
+        else
+        {
+            ShowMessages("no hex number was provided as process id.\n\n");
+            return CmdEmpty;
+        }
+    }
+    else
+    {
+        // user didn't provide pid at all. ignoring.
+    }
+
+    // fill the CMD object. will be optimized later.
+    if (CmdVec.size() > 0)
+        CMD.Command_str = CmdVec.at(0);
+    if (CmdVec.size() > 1)
+        CMD.Address_str = CmdVec.at(1);
+    if (CmdVec.size() > 2)
+        CMD.AsmSnippet = CmdVec.at(2);
+    if (CmdVec.size() > 3)
+        CMD.Start_Address_str = CmdVec.at(3);
+    // if (CmdVec.size() > 4) CMD.ProcId_str        = CmdVec.at(5);  4 is the "pid" string
+
+    return CMD;
 }
 
 static bool
@@ -277,14 +310,14 @@ Assemble(ks_arch arch, int mode, uint64_t start_addr, int syntax, AssembleData &
     {
         if (asmbDat.BytesCount == 0)
         {
-            ShowMessages("err, the assemble operation returned no bytes, most likely due to incorrect formatting.\n");
+            ShowMessages("err, the assemble operation returned no bytes, most likely due to incorrect formatting of assembly snippet.\n");
         }
         else
         {
             ShowMessages("generated assembly: %lu bytes, %lu statements ==>> ", (int)asmbDat.BytesCount, (int)asmbDat.StatementCount);
 
             size_t i;
-            ShowMessages("%s = ", asmbDat.AsmRaw.c_str());
+            ShowMessages("%s = ", asmbDat.AsmFixed.c_str());
             for (i = 0; i < asmbDat.BytesCount; i++)
             {
                 ShowMessages("%02x ", asmbDat.EncodedBytes[i]);
@@ -310,78 +343,86 @@ Assemble(ks_arch arch, int mode, uint64_t start_addr, int syntax, AssembleData &
 VOID
 CommandAssemble(vector<string> SplitCommand, string Command)
 {
+    DEBUGGER_EDIT_MEMORY_TYPE MemoryType {};
+    _CMD                      CMD {};
     UINT64                    Address {};
-    vector<UINT64>            ValuesToEdit {};
-    DEBUGGER_EDIT_MEMORY      EditMemoryRequest {};
-    UINT64                    Value {};
-    UINT32                    ProcId {};
-    DEBUGGER_EDIT_MEMORY_TYPE MemoryType;
+    UINT64                    Start_Address {};
+    UINT32                    ProcId = 0;
+
+    CMD = ParseUserCmd(Command);
+
+    if (CMD.isEmpty())
+    {
+        // error messeges are already printed
+        return;
+    }
+
+    if (!CMD.ProcId_str.empty())
+    {
+        if (!ConvertStringToUInt32(CMD.ProcId_str, &ProcId))
+        {
+            ShowMessages("please specify a correct hex process id\n\n");
+            CommandAssembleHelp();
+            return;
+        }
+    }
 
     if (g_ActiveProcessDebuggingState.IsActive)
     {
         ProcId = g_ActiveProcessDebuggingState.ProcessId;
     }
 
-    std::vector<std::string> CmdVec = ParseUserCmd(Command);
-
-    if (CmdVec.size() < 3)
+    if (CMD.AsmSnippet.empty())
     {
-        ShowMessages("incorrect use of the 'a'\n\n");
+        ShowMessages("no assembly snippet provided\n");
         CommandAssembleHelp();
         return;
     }
-    else if (CmdVec[0] == "a")
+    else if (CMD.Command_str == "a")
     {
         MemoryType = EDIT_VIRTUAL_MEMORY;
     }
-    else if (CmdVec[0] == "!a")
+    else if (CMD.Command_str == "!a")
     {
         MemoryType = EDIT_PHYSICAL_MEMORY;
     }
     else
     {
-        ShowMessages("incorrect use of the 'a'\n\n");
+        ShowMessages("unknown assemble command.\n\n");
         CommandAssembleHelp();
         return;
-    }
-
-    // check if there is any "pid"
-    auto it = std::find_if(CmdVec.begin(), CmdVec.end(), [](const std::string & s) { return s.find("pid") != std::string::npos; });
-    if (it != CmdVec.end())
-    {
-        if (g_IsSerialConnectedToRemoteDebuggee)
-        {
-            ShowMessages(ASSERT_MESSAGE_CANNOT_SPECIFY_PID);
-            return;
-        }
-
-        if (std::next(it) != CmdVec.end()) // is there anything after "pid"?
-        {
-            if (!ConvertStringToUInt32(std::string(*(++it)), &ProcId))
-            {
-                ShowMessages("please specify a correct hex process id\n\n");
-                CommandAssembleHelp();
-                return;
-            }
-        }
-    }
-    else
-    {
-        // pid Not found
     }
 
     // fetching start_address i.e. address to assemble to
-    if (!SymbolConvertNameOrExprToAddress(CmdVec.at(1), &Address))
+    if (!CMD.Address_str.empty()) // was any address provided to assemble to?
     {
-        ShowMessages("err, couldn't resolve Address at '%s'\n\n",
-                     CmdVec.at(1).c_str());
-        CommandAssembleHelp();
-        return;
+        if (!SymbolConvertNameOrExprToAddress(CMD.Address_str, &Address))
+        {
+            ShowMessages("err, couldn't resolve Address at '%s'\n\n",
+                         CMD.Address_str.c_str());
+            CommandAssembleHelp();
+            return;
+        }
+    }
+    else if (!CMD.Start_Address_str.empty()) // was a custom start_address provided?
+    {
+        if (!SymbolConvertNameOrExprToAddress(CMD.Start_Address_str, &Start_Address))
+        {
+            ShowMessages("err, couldn't resolve Address at '%s'\n\n",
+                         CMD.Start_Address_str.c_str());
+            CommandAssembleHelp();
+            return;
+        }
+        Address = Start_Address;
+    }
+    else
+    {
+        ShowMessages("warn, no start_address provided to calculate relative asm commands.\n\n");
     }
 
     AssembleData AssembleData;
-    AssembleData.AsmRaw = CmdVec.at(2);
-    parseAssemblyLine(AssembleData);
+    AssembleData.AsmRaw = CMD.AsmSnippet; // third element
+    AssembleData.parseAssemblyData();
 
     if (Assemble(KS_ARCH_X86, KS_MODE_64, Address, KS_OPT_SYNTAX_INTEL, AssembleData))
     {
@@ -395,17 +436,20 @@ CommandAssemble(vector<string> SplitCommand, string Command)
         ProcId = GetCurrentProcessId();
     }
 
-    if (HyperDbgWriteMemory(
-            (PVOID)Address,
-            MemoryType,
-            ProcId,
-            (PVOID)AssembleData.EncodedBytes,
-            (UINT32)AssembleData.BytesCount))
+    if (Address) // was the user only trying to get the bytes?
     {
-        ShowMessages("successfully assembled at 0x%016llx address.\n", static_cast<uint64_t>(Address));
-    }
-    else
-    {
-        ShowMessages("failed to write generated assembly to memory.");
+        if (HyperDbgWriteMemory(
+                (PVOID)Address,
+                MemoryType,
+                ProcId,
+                (PVOID)AssembleData.EncodedBytes,
+                (UINT32)AssembleData.BytesCount))
+        {
+            ShowMessages("successfully assembled at 0x%016llx address.\n", static_cast<uint64_t>(Address));
+        }
+        else
+        {
+            ShowMessages("failed to write generated assembly to memory.");
+        }
     }
 }


### PR DESCRIPTION
# Description

improved asm snippet parse
symbols are now needed to be in <>
now user can get machine code from asm snippet without writing it to memory.

## Type of change

now this kind of command can be done:
```
a nt!ExAllocatePoolWithTag+@rax+1 {  nop   ;    inc    rax    ;   nop   ;
   add    rax,1   ;  
  add  DWORD PTR  [    rax+8   ]   ,   <nt!ExAllocatePoolWithTag+@rax+10>;
  add    rax   ,   [ <nt!ExAllocatePoolWithTag+@rax+1>  ]
}

```

or to just get the x86 machine code:
```
a {  nop   ;    inc    rax    ;   nop   ;
   add    rax,1   ;  
  add  DWORD PTR  [    rax+8   ]   ,   <nt!ExAllocatePoolWithTag+@rax+10>;
  add    rax   ,   [ <nt!ExAllocatePoolWithTag+@rax+1>  ]
}
```