### PR TITLE
made assembler a class - add "asm" to epthook's "condition" and "code"

### DIFF
--- a/hyperdbg/libhyperdbg/code/debugger/misc/assembler.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/misc/assembler.cpp
@@ -1,0 +1,190 @@
+/**
+ * @file assembler.cpp
+ * @author Abbas Masoumi Gorji
+ * @brief turns asm code into byte
+ * @details
+ * @version 0.1
+ * @date 2024-7-16
+ *
+ * @copyright This project is released under the GNU Public License v3.
+ *
+ */
+
+#include "pch.h"
+
+/**
+ * @brief tries to solve the symbol issue with Keystone, which apparently originates from LLVM-MC.
+ *
+ * @return VOID
+ */
+VOID
+AssembleData::ParseAssemblyData()
+{
+    std::string RawAsm = AsmRaw;
+
+    //
+    // remove all "\n" instances
+    //
+    RawAsm.erase(std::remove(RawAsm.begin(), RawAsm.end(), '\n'), RawAsm.end());
+
+    //
+    // remove multiple spaces
+    //
+    std::regex MultipleSpaces(" +");
+    RawAsm = std::regex_replace(RawAsm, MultipleSpaces, " ");
+
+    //
+    // split assembly line by ';'
+    //
+    std::vector<std::string> AssemblyInstructions;
+    size_t                   Pos       = 0;
+    std::string              Delimiter = ";";
+    while ((Pos = RawAsm.find(Delimiter)) != std::string::npos)
+    {
+        std::string Token = RawAsm.substr(0, Pos);
+        if (!Token.empty())
+        {
+            AssemblyInstructions.push_back(Token);
+        }
+        RawAsm.erase(0, Pos + Delimiter.length());
+    }
+    if (!RawAsm.empty())
+    {
+        AssemblyInstructions.push_back(RawAsm);
+    }
+
+    //
+    // process each assembly instruction
+    //
+    for (auto & InstructionLine : AssemblyInstructions)
+    {
+        std::string Expr {};
+        UINT64      ExprAddr {};
+        size_t      Start {};
+
+        while ((Start = InstructionLine.find('<', Start)) != std::string::npos)
+        {
+            size_t End = InstructionLine.find('>', Start);
+            if (End != std::string::npos)
+            {
+                std::string Expr = InstructionLine.substr(Start + 1, End - Start - 1);
+                if (!SymbolConvertNameOrExprToAddress(Expr, &ExprAddr) && ExprAddr == 0)
+                {
+                    ShowMessages("err, failed to resolve the symbol [ %s ].\n", Expr.c_str());
+                    Start += Expr.size() + 2;
+                    continue;
+                }
+
+                std::ostringstream Oss;
+                Oss << std::hex << std::showbase << ExprAddr;
+                InstructionLine.replace(Start, End - Start + 1, Oss.str());
+            }
+            else
+            {
+                //
+                // No matching '>' found, break the loop
+                //
+                break;
+            }
+            Start += Expr.size() + 2;
+        }
+    }
+
+    //
+    // Append ";" between two std::strings
+    //
+    auto ApndSemCln = [](std::string a, std::string b) {
+        return std::move(a) + ';' + std::move(b);
+    };
+
+    //
+    // Concatenate each assembly line
+    //
+    AsmFixed = std::accumulate(std::next(AssemblyInstructions.begin()), AssemblyInstructions.end(), AssemblyInstructions.at(0), ApndSemCln);
+
+    if (!AsmFixed.empty() && AsmFixed.back() == ';')
+    {
+        //
+        // remove the last ";" for it will be counted as a statement by Keystone and a wrong number would be printed
+        //
+        AsmFixed.pop_back();
+    }
+
+    while (!AsmFixed.empty() && AsmFixed.back() == ';')
+    {
+        AsmFixed.pop_back();
+    }
+}
+
+INT
+AssembleData::Assemble(UINT64 StartAddr, ks_arch Arch, INT Mode, INT Syntax)
+{
+    ks_engine * Ks;
+
+    KsErr = ks_open(Arch, Mode, &Ks);
+    if (KsErr != KS_ERR_OK)
+    {
+        ShowMessages("err, failed on ks_open()");
+        return -1;
+    }
+
+    if (Syntax)
+    {
+        KsErr = ks_option(Ks, KS_OPT_SYNTAX, Syntax);
+        if (KsErr != KS_ERR_OK)
+        {
+            ShowMessages("err, failed on ks_option() with error code = %u\n", KsErr);
+        }
+    }
+
+    //
+    // as long as symbols are parsed before passing asm code, SymResolver is not needed, for now.
+    //
+    KsErr = ks_option(Ks, KS_OPT_SYM_RESOLVER, 0); // null SymResolver
+    if (KsErr != KS_ERR_OK)
+    {
+        ShowMessages("err, failed on ks_option() with error code = %u\n", KsErr);
+    }
+
+    if (ks_asm(Ks, AsmFixed.c_str(), StartAddr, &EncodedBytes, &BytesCount, &StatementCount))
+    {
+        KsErr = ks_errno(Ks);
+        ShowMessages("err, failed on ks_asm() with count = %lu, error code = %u\n", (int)StatementCount, KsErr);
+    }
+    else
+    {
+        if (BytesCount == 0)
+        {
+            ShowMessages("err, the assemble operation returned no bytes, most likely due to incorrect formatting of assembly snippet\n");
+        }
+        else
+        {
+            //
+            // inserting zero termination for compatibility with C functions
+            //
+            EncodedBytes[BytesCount] = '\0'; 
+
+            ShowMessages("generated assembly: %lu bytes, %lu statements ==>> ", (int)BytesCount, (int)StatementCount);
+
+            size_t i;
+            ShowMessages("%s = ", AsmFixed.c_str());
+            for (i = 0; i < BytesCount; i++)
+            {
+                ShowMessages("%02x ", EncodedBytes[i]);
+                EncBytesIntVec.push_back(static_cast<UINT64>(EncodedBytes[i]));
+            }
+            ShowMessages("\n");
+
+            ks_close(Ks);
+            return 0;
+        }
+    }
+    ks_close(Ks);
+    return -1;
+}
+
+AssembleData *
+create_AssembleData()
+{
+    return new AssembleData;
+}

--- a/hyperdbg/libhyperdbg/header/assembler.h
+++ b/hyperdbg/libhyperdbg/header/assembler.h
@@ -1,0 +1,31 @@
+/**
+* 
+* @author Abbas Masoumi Gorji
+* @date 2024-7-16
+* 
+**/
+
+#pragma once
+
+#include "pch.h"
+
+
+class AssembleData
+{
+public:
+    std::string     AsmRaw {};
+    std::string     AsmFixed {};
+    size_t          StatementCount {};
+    size_t          BytesCount {};
+    unsigned char * EncodedBytes {};
+    vector<UINT64>  EncBytesIntVec {};
+    ks_err          KsErr {};
+
+    AssembleData() = default;
+
+    VOID
+    ParseAssemblyData();
+
+    INT
+    Assemble(UINT64 StartAddr, ks_arch Arch = KS_ARCH_X86, INT Mode = KS_MODE_64, INT Syntax = KS_OPT_SYNTAX_INTEL);
+};

--- a/hyperdbg/libhyperdbg/libhyperdbg.vcxproj
+++ b/hyperdbg/libhyperdbg/libhyperdbg.vcxproj
@@ -126,6 +126,7 @@
   <ItemGroup>
     <ClInclude Include="..\include\platform\user\header\Environment.h" />
     <ClInclude Include="..\include\platform\user\header\Windows.h" />
+    <ClInclude Include="header\assembler.h" />
     <ClInclude Include="header\commands.h" />
     <ClInclude Include="header\common.h" />
     <ClInclude Include="header\communication.h" />
@@ -184,6 +185,7 @@
     <ClCompile Include="code\debugger\core\interpreter.cpp" />
     <ClCompile Include="code\debugger\kernel-level\kd.cpp" />
     <ClCompile Include="code\debugger\kernel-level\kernel-listening.cpp" />
+    <ClCompile Include="code\debugger\misc\assembler.cpp" />
     <ClCompile Include="code\debugger\misc\callstack.cpp" />
     <ClCompile Include="code\debugger\misc\disassembler.cpp" />
     <ClCompile Include="code\debugger\misc\readmem.cpp" />

--- a/hyperdbg/libhyperdbg/libhyperdbg.vcxproj.filters
+++ b/hyperdbg/libhyperdbg/libhyperdbg.vcxproj.filters
@@ -164,6 +164,9 @@
     <ClInclude Include="header\libhyperdbg.h">
       <Filter>header</Filter>
     </ClInclude>
+    <ClInclude Include="header\assembler.h">
+      <Filter>header</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -543,6 +546,9 @@
     </ClCompile>
     <ClCompile Include="code\debugger\commands\debugging-commands\a.cpp">
       <Filter>code\debugger\commands\debugging-commands</Filter>
+    </ClCompile>
+    <ClCompile Include="code\debugger\misc\assembler.cpp">
+      <Filter>code\debugger\misc</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/hyperdbg/libhyperdbg/pch.h
+++ b/hyperdbg/libhyperdbg/pch.h
@@ -164,6 +164,7 @@ typedef const wchar_t *LPCWCHAR, *PCWCHAR;
 #include "header/ud.h"
 #include "header/objects.h"
 #include "header/rev-ctrl.h"
+#include "header/assembler.h"
 #include <regex>
 //
 // hwdbg


### PR DESCRIPTION
# Description

assembler is now a class
[!epthook]'s condition and code now can use asm code:
`!epthook nt!ExAllocatePoolWithTag condition asm { nop; nop; int3; nop; nop} code asm { nop; nop; int3 }
`

assembler needs to exported in exprot.cpp
suggestion for better syntax is welcome

