### PR TITLE
fix compatibility mode program crash when terminate vm

### DIFF
--- a/hyperdbg/hyperhv/code/assembly/AsmSegmentRegs.asm
+++ b/hyperdbg/hyperhv/code/assembly/AsmSegmentRegs.asm
@@ -1,8 +1,12 @@
 PUBLIC AsmGetCs
 PUBLIC AsmGetDs
+PUBLIC AsmSetDs
 PUBLIC AsmGetEs
+PUBLIC AsmSetEs
 PUBLIC AsmGetSs
+PUBLIC AsmSetSs
 PUBLIC AsmGetFs
+PUBLIC AsmSetFs
 PUBLIC AsmGetGs
 PUBLIC AsmGetLdtr
 PUBLIC AsmGetTr
@@ -44,12 +48,32 @@ AsmGetDs ENDP
 
 ;------------------------------------------------------------------------
 
+AsmSetDs PROC
+
+    mov     rax, rcx
+    mov     ds, rax 
+    ret
+
+AsmSetDs ENDP
+
+;------------------------------------------------------------------------
+
 AsmGetEs PROC
 
     mov     rax, es
     ret
 
 AsmGetEs ENDP
+
+;------------------------------------------------------------------------
+
+AsmSetEs PROC
+
+    mov     rax, rcx
+    mov     es, rax 
+    ret
+
+AsmSetEs ENDP
 
 ;------------------------------------------------------------------------
 
@@ -62,12 +86,32 @@ AsmGetSs ENDP
 
 ;------------------------------------------------------------------------
 
+AsmSetSs PROC
+
+    mov     rax, rcx
+    mov     ss, rax 
+    ret
+
+AsmSetSs ENDP
+
+;------------------------------------------------------------------------
+
 AsmGetFs PROC
 
     mov     rax, fs
     ret
 
 AsmGetFs ENDP
+
+;------------------------------------------------------------------------
+
+AsmSetFs PROC
+
+    mov     rax, rcx
+    mov     fs, rax 
+    ret
+
+AsmSetFs ENDP
 
 ;------------------------------------------------------------------------
 

--- a/hyperdbg/hyperhv/code/vmm/vmx/Hv.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/Hv.c
@@ -468,6 +468,11 @@ HvRestoreRegisters()
     UINT64 GdtrLimit;
     UINT64 IdtrBase;
     UINT64 IdtrLimit;
+    UINT16 DsSelector;
+    UINT16 EsSelector;
+    UINT16 SsSelector;
+    UINT16 FsSelector;
+
 
     //
     // Restore FS Base
@@ -488,6 +493,18 @@ HvRestoreRegisters()
     __vmx_vmread(VMCS_GUEST_GDTR_LIMIT, &GdtrLimit);
 
     AsmReloadGdtr((void *)GdtrBase, (unsigned long)GdtrLimit);
+
+    //
+    // Restore Segment Selector
+    //
+    VmxVmread16P(VMCS_GUEST_DS_SELECTOR, &DsSelector);
+    AsmSetDs(DsSelector);
+    VmxVmread16P(VMCS_GUEST_ES_SELECTOR, &EsSelector);
+    AsmSetEs(EsSelector);
+    VmxVmread16P(VMCS_GUEST_SS_SELECTOR, &SsSelector);
+    AsmSetSs(SsSelector);
+    VmxVmread16P(VMCS_GUEST_FS_SELECTOR, &FsSelector);
+    AsmSetFs(FsSelector);
 
     //
     // Restore IDTR

--- a/hyperdbg/hyperhv/header/assembly/InlineAsm.h
+++ b/hyperdbg/hyperhv/header/assembly/InlineAsm.h
@@ -143,6 +143,9 @@ AsmGetCs();
 extern unsigned short
 AsmGetDs();
 
+extern void 
+AsmSetDs(unsigned short DsSelector);
+
 /**
  * @brief Get ES Register
  *
@@ -150,6 +153,9 @@ AsmGetDs();
  */
 extern unsigned short
 AsmGetEs();
+
+extern void
+AsmSetEs(unsigned short EsSelector);
 
 /**
  * @brief Get SS Register
@@ -159,6 +165,9 @@ AsmGetEs();
 extern unsigned short
 AsmGetSs();
 
+extern void
+AsmSetSs(unsigned short SsSelector);
+
 /**
  * @brief Get FS Register
  *
@@ -166,6 +175,9 @@ AsmGetSs();
  */
 extern unsigned short
 AsmGetFs();
+
+extern void
+AsmSetFs(unsigned short FsSelector);
 
 /**
  * @brief Get GS Register


### PR DESCRIPTION
# Description

Set the segment selector when terminate vm. Some compatibility mode program may throw GP if we do not do this. 