### PR TITLE
Fix: replaced sprintf with sprintf_s to improve safety

### DIFF
--- a/hyperdbg/script-eval/code/Functions.c
+++ b/hyperdbg/script-eval/code/Functions.c
@@ -1033,7 +1033,7 @@ ApplyFormatSpecifier(const CHAR * CurrentSpecifier, CHAR * FinalBuffer, PUINT32 
 
     *CurrentProcessedPositionFromStartOfFormat =
         *CurrentProcessedPositionFromStartOfFormat + (UINT32)strlen(CurrentSpecifier);
-    sprintf(TempBuffer, CurrentSpecifier, Val);
+    sprintf_s(TempBuffer, sizeof(TempBuffer), CurrentSpecifier, Val);
     TempBufferLen = (UINT32)strlen(TempBuffer);
 
     //


### PR DESCRIPTION
This PR replaces the usage of `sprintf` with the safer `sprintf_s` function in the `ApplyFormatSpecifier` function. The change improves safety by preventing potential buffer overflows.

While the program is currently **NOT vulnerable**—because `FormatSpecifier` in `ScriptEngineFunctionPrintf` is limited to 5-bytes —future misuse of this function could lead to issues. This update ensures that the function remains secure against improper use or unexpected input.

**Note**: I have not tested this change completely, so I kindly request reviewers to test it thoroughly before merging. Thank you!

