### PR TITLE
Fix symbol 24h2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1.0] - 2025-XX-XX
+New release of the HyperDbg Debugger.
+
+### Added
+- 
+
+### Changed
+- Fix the 'lm' command issue of not showing kernel module addresses (KASLR leak mitigation) introduced in Win 11 24h2
+
 ## [0.12.0.0] - 2025-01-02
 New release of the HyperDbg Debugger.
 

--- a/hyperdbg/include/SDK/headers/Constants.h
+++ b/hyperdbg/include/SDK/headers/Constants.h
@@ -18,7 +18,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 12
-#define VERSION_PATCH 0
+#define VERSION_PATCH 1
 
 //
 // Example of __DATE__ string: "Jul 27 2012"

--- a/hyperdbg/libhyperdbg/code/app/libhyperdbg.cpp
+++ b/hyperdbg/libhyperdbg/code/app/libhyperdbg.cpp
@@ -32,6 +32,7 @@ extern BOOLEAN    g_OutputSourcesInitialized;
 extern BOOLEAN    g_IsSerialConnectedToRemoteDebugger;
 extern BOOLEAN    g_IsDebuggerModulesLoaded;
 extern BOOLEAN    g_IsReversingMachineModulesLoaded;
+extern BOOLEAN    g_PrivilegesAlreadyAdjusted;
 extern LIST_ENTRY g_OutputSources;
 
 /**
@@ -504,6 +505,14 @@ SetDebugPrivilege()
     HANDLE Token;
 
     //
+    // Check if we already adjusted the privilege
+    //
+    if (g_PrivilegesAlreadyAdjusted)
+    {
+        return TRUE;
+    }
+
+    //
     // Enable Debug privilege
     //
     Status = OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &Token);
@@ -519,6 +528,11 @@ SetDebugPrivilege()
         CloseHandle(Token);
         return FALSE;
     }
+
+    //
+    // Indicate that the privilege is already adjusted
+    //
+    g_PrivilegesAlreadyAdjusted = TRUE;
 
     CloseHandle(Token);
     return TRUE;

--- a/hyperdbg/libhyperdbg/code/common/common.cpp
+++ b/hyperdbg/libhyperdbg/code/common/common.cpp
@@ -674,7 +674,7 @@ SetPrivilege(HANDLE  Token,          // access token handle
 
     if (GetLastError() == ERROR_NOT_ALL_ASSIGNED)
     {
-        ShowMessages("err, the token does not have the specified privilege (ACCESS DENIED!)\n");
+        ShowMessages("err, the token does not have the specified (debug) privilege (ACCESS DENIED!)\n");
         ShowMessages("make sure to run it with administrator privileges\n");
         return FALSE;
     }

--- a/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/lm.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/lm.cpp
@@ -276,7 +276,7 @@ CommandLmShowKernelModeModule(const char * SearchModule)
     PRTL_PROCESS_MODULES ModulesInfo = NULL;
     string               SearchModuleString;
 
-    if (SymbolCheckAndAllocateModuleInformation(ModulesInfo) == FALSE)
+    if (SymbolCheckAndAllocateModuleInformation(&ModulesInfo) == FALSE)
     {
         ShowMessages("err, unable get modules information\n");
         return FALSE;

--- a/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/lm.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/lm.cpp
@@ -273,41 +273,12 @@ CommandLmShowUserModeModule(UINT32 ProcessId, const char * SearchModule)
 BOOLEAN
 CommandLmShowKernelModeModule(const char * SearchModule)
 {
-    NTSTATUS             Status = STATUS_UNSUCCESSFUL;
-    PRTL_PROCESS_MODULES ModulesInfo;
-    ULONG                SysModuleInfoBufferSize = 0;
+    PRTL_PROCESS_MODULES ModulesInfo = NULL;
     string               SearchModuleString;
 
-    //
-    // Get required size of "RTL_PROCESS_MODULES" buffer
-    //
-    Status = NtQuerySystemInformation((SYSTEM_INFORMATION_CLASS)SystemModuleInformation, NULL, NULL, &SysModuleInfoBufferSize);
-
-    //
-    // Allocate memory for the module list
-    //
-    ModulesInfo = (PRTL_PROCESS_MODULES)VirtualAlloc(
-        NULL,
-        SysModuleInfoBufferSize,
-        MEM_COMMIT | MEM_RESERVE,
-        PAGE_READWRITE);
-
-    if (!ModulesInfo)
+    if (SymbolCheckAndAllocateModuleInformation(ModulesInfo) == FALSE)
     {
-        ShowMessages("err, unable to allocate memory for module list (%x)\n",
-                     GetLastError());
-        return FALSE;
-    }
-
-    Status = NtQuerySystemInformation((SYSTEM_INFORMATION_CLASS)SystemModuleInformation,
-                                      ModulesInfo,
-                                      SysModuleInfoBufferSize,
-                                      NULL);
-    if (!NT_SUCCESS(Status))
-    {
-        ShowMessages("err, unable to query module list (%x)\n", Status);
-
-        VirtualFree(ModulesInfo, 0, MEM_RELEASE);
+        ShowMessages("err, unable get modules information\n");
         return FALSE;
     }
 
@@ -369,7 +340,7 @@ CommandLmShowKernelModeModule(const char * SearchModule)
         ShowMessages("%s\n", CurrentModule->FullPathName);
     }
 
-    VirtualFree(ModulesInfo, 0, MEM_RELEASE);
+    free(ModulesInfo);
 
     return TRUE;
 }

--- a/hyperdbg/libhyperdbg/code/debugger/core/debugger.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/core/debugger.cpp
@@ -557,24 +557,14 @@ ShowErrorMessage(UINT32 Error)
 UINT64
 DebuggerGetNtoskrnlBase()
 {
-    NTSTATUS             Status                  = STATUS_UNSUCCESSFUL;
-    UINT64               NtoskrnlBase            = NULL;
-    PRTL_PROCESS_MODULES Modules                 = NULL;
-    ULONG                SysModuleInfoBufferSize = 0;
+    UINT64               NtoskrnlBase = NULL;
+    PRTL_PROCESS_MODULES Modules      = NULL;
 
-    //
-    // Get required size of "RTL_PROCESS_MODULES" buffer
-    //
-    Status = NtQuerySystemInformation((SYSTEM_INFORMATION_CLASS)SystemModuleInformation, NULL, NULL, &SysModuleInfoBufferSize);
-
-    Modules = (PRTL_PROCESS_MODULES)malloc(SysModuleInfoBufferSize);
-
-    if (Modules == NULL)
+    if (SymbolCheckAndAllocateModuleInformation(Modules) == FALSE)
     {
+        ShowMessages("err, unable to get the module list for getting ntoskrnl base address\n");
         return NULL64_ZERO;
     }
-
-    NtQuerySystemInformation((SYSTEM_INFORMATION_CLASS)SystemModuleInformation, Modules, SysModuleInfoBufferSize, NULL);
 
     for (UINT32 i = 0; i < Modules->NumberOfModules; i++)
     {

--- a/hyperdbg/libhyperdbg/code/debugger/core/debugger.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/core/debugger.cpp
@@ -560,7 +560,7 @@ DebuggerGetNtoskrnlBase()
     UINT64               NtoskrnlBase = NULL;
     PRTL_PROCESS_MODULES Modules      = NULL;
 
-    if (SymbolCheckAndAllocateModuleInformation(Modules) == FALSE)
+    if (SymbolCheckAndAllocateModuleInformation(&Modules) == FALSE)
     {
         ShowMessages("err, unable to get the module list for getting ntoskrnl base address\n");
         return NULL64_ZERO;

--- a/hyperdbg/libhyperdbg/code/debugger/script-engine/symbol.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/script-engine/symbol.cpp
@@ -526,7 +526,7 @@ SymbolBuildSymbolTable(PMODULE_SYMBOL_DETAIL * BufferToStoreDetails,
     //              Get kernel-mode modules information
     // *****************************************************************
     //
-    if (SymbolCheckAndAllocateModuleInformation(ModuleInfo))
+    if (SymbolCheckAndAllocateModuleInformation(&ModuleInfo))
     {
         ShowMessages("err, unable to get module information\n");
         return FALSE;
@@ -1002,7 +1002,7 @@ SymbolReloadSymbolTableInDebuggerMode(UINT32 ProcessId)
  * @return BOOLEAN
  */
 BOOLEAN
-SymbolCheckAndAllocateModuleInformation(PRTL_PROCESS_MODULES Modules)
+SymbolCheckAndAllocateModuleInformation(PRTL_PROCESS_MODULES * Modules)
 {
     NTSTATUS Status                  = STATUS_UNSUCCESSFUL;
     ULONG    SysModuleInfoBufferSize = 0;
@@ -1021,9 +1021,14 @@ SymbolCheckAndAllocateModuleInformation(PRTL_PROCESS_MODULES Modules)
     //
     Status = NtQuerySystemInformation((SYSTEM_INFORMATION_CLASS)SystemModuleInformation, NULL, NULL, &SysModuleInfoBufferSize);
 
-    Modules = (PRTL_PROCESS_MODULES)malloc(SysModuleInfoBufferSize);
+    //
+    // print the size of the buffer
+    //
+    // ShowMessages("size of the buffer : %x\n", SysModuleInfoBufferSize);
 
-    if (!NT_SUCCESS(Status) || Modules == NULL)
+    *Modules = (PRTL_PROCESS_MODULES)malloc(SysModuleInfoBufferSize);
+
+    if (*Modules == NULL)
     {
         ShowMessages("err, unable to allocate memory for module list (%x)\n",
                      GetLastError());
@@ -1033,12 +1038,12 @@ SymbolCheckAndAllocateModuleInformation(PRTL_PROCESS_MODULES Modules)
     //
     // Get the module list
     //
-    Status = NtQuerySystemInformation((SYSTEM_INFORMATION_CLASS)SystemModuleInformation, Modules, SysModuleInfoBufferSize, NULL);
+    Status = NtQuerySystemInformation((SYSTEM_INFORMATION_CLASS)SystemModuleInformation, *Modules, SysModuleInfoBufferSize, NULL);
 
     if (!NT_SUCCESS(Status))
     {
         ShowMessages("err, unable to query module list (%x)\n", Status);
-        free(Modules);
+        free(*Modules);
 
         return FALSE;
     }

--- a/hyperdbg/libhyperdbg/code/debugger/script-engine/symbol.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/script-engine/symbol.cpp
@@ -526,7 +526,7 @@ SymbolBuildSymbolTable(PMODULE_SYMBOL_DETAIL * BufferToStoreDetails,
     //              Get kernel-mode modules information
     // *****************************************************************
     //
-    if (SymbolCheckAndAllocateModuleInformation(&ModuleInfo))
+    if (SymbolCheckAndAllocateModuleInformation(&ModuleInfo) == FALSE)
     {
         ShowMessages("err, unable to get module information\n");
         return FALSE;

--- a/hyperdbg/libhyperdbg/header/globals.h
+++ b/hyperdbg/libhyperdbg/header/globals.h
@@ -559,6 +559,11 @@ BOOLEAN g_IsInstrumentingInstructions = FALSE;
  */
 UINT64 g_KernelBaseAddress;
 
+/**
+ * @brief Is privileges already adjusted
+ */
+BOOLEAN g_PrivilegesAlreadyAdjusted = FALSE;
+
 //////////////////////////////////////////////////
 //			     	 Settings			        //
 //////////////////////////////////////////////////

--- a/hyperdbg/libhyperdbg/header/libhyperdbg.h
+++ b/hyperdbg/libhyperdbg/header/libhyperdbg.h
@@ -60,3 +60,6 @@ SetTextMessageCallbackUsingSharedBuffer(PVOID Handler);
 
 VOID
 UnsetTextMessageCallback();
+
+BOOLEAN
+SetDebugPrivilege();

--- a/hyperdbg/libhyperdbg/header/symbol.h
+++ b/hyperdbg/libhyperdbg/header/symbol.h
@@ -73,4 +73,4 @@ BOOLEAN
 SymbolReloadSymbolTableInDebuggerMode(UINT32 ProcessId);
 
 BOOLEAN
-SymbolCheckAndAllocateModuleInformation(PRTL_PROCESS_MODULES Modules);
+SymbolCheckAndAllocateModuleInformation(PRTL_PROCESS_MODULES * Modules);

--- a/hyperdbg/libhyperdbg/header/symbol.h
+++ b/hyperdbg/libhyperdbg/header/symbol.h
@@ -71,3 +71,6 @@ SymbolPrepareDebuggerWithSymbolInfo(UINT32 UserProcessId);
 
 BOOLEAN
 SymbolReloadSymbolTableInDebuggerMode(UINT32 ProcessId);
+
+BOOLEAN
+SymbolCheckAndAllocateModuleInformation(PRTL_PROCESS_MODULES Modules);


### PR DESCRIPTION
### Changed
- Fix the 'lm' command issue of not showing kernel module addresses (KASLR leak mitigation) introduced in Win 11 24h2