### PR TITLE
update parser

### DIFF
--- a/hyperdbg/libhyperdbg/code/debugger/core/interpreter.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/core/interpreter.cpp
@@ -315,7 +315,14 @@ public:
                     {
                         input.erase(i - 1, 1);
                         i--;                // compensate for the removed char
-                        current.pop_back(); // remove last read \\ 
+
+                        //
+                        // remove last read "\\" if we are not within a {}
+                        //
+                        if (!IdxBracket)
+                        {
+                            current.pop_back(); 
+                        }
                         current += c;
                         continue;
                     }


### PR DESCRIPTION
# Description
a simple fix for bug preventing correct parsing of 
```
script { printf();}
```
