### PR TITLE
fix .thread crash

### DIFF
--- a/hyperdbg/hyperkd/code/debugger/objects/Thread.c
+++ b/hyperdbg/hyperkd/code/debugger/objects/Thread.c
@@ -280,9 +280,9 @@ ThreadShowList(PDEBUGGEE_THREAD_LIST_NEEDED_DETAILS               ThreadListSymb
             SavingEntries[EnumerationCount - 1].ThreadId  = HANDLE_TO_UINT32(ThreadCid.UniqueThread);
             SavingEntries[EnumerationCount - 1].Ethread   = Thread;
 
-            RtlCopyMemory(&SavingEntries[EnumerationCount - 1].ImageFileName,
-                          CommonGetProcessNameFromProcessControlBlock((PEPROCESS)ThreadListSymbolInfo->Process),
-                          15);
+            MemoryMapperReadMemorySafe((UINT64)CommonGetProcessNameFromProcessControlBlock((PEPROCESS)ThreadListSymbolInfo->Process),
+                                       &SavingEntries[EnumerationCount - 1].ImageFileName,
+                                       15);
 
             break;
 


### PR DESCRIPTION
# Description

For some reason, I get a SYSTEM_SERVICE_EXCEPTION bluescreen of death when using `.thread list` or `.thread list process <process>`. Swapping the RtlCopyMemory to a safe alternative fixes the crash. This might well stem from some deeper issue that needs fixing but at least this prevents the bsod.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

I couldn't find anyone else with this issue so I'll document the environment where this happens:
 - OS: Win 10 22H2
 - Processor: Intel i5-7500
 - Environment: Physical Machine