### PR TITLE
v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.2.0] - 2025-XX-XX
+## [0.13.2.0] - 2025-05-26
 New release of the HyperDbg Debugger.
 
 ### Added
+- Intercepting system-call return results using the TRAP flag for the transparent-mode
+- Added optional parameters and context for the transparent-mode system-call return interceptions
 
 ### Changed
 - Set variable length (stack frames) for showing the callstack ([link](https://docs.hyperdbg.org/commands/debugging-commands/k))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ New release of the HyperDbg Debugger.
 
 ### Changed
 - Set variable length (stack frames) for showing the callstack ([link](https://docs.hyperdbg.org/commands/debugging-commands/k))
+- Fixed VMCS layout corruption due to NMI injection (VMRESUME 0x7 error) in nested-virtualization on Meteor Lake processors
+- Restore RDMSR handler for VM-exits
 
 ## [0.13.1.0] - 2025-04-14
 New release of the HyperDbg Debugger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2.0] - 2025-XX-XX
+New release of the HyperDbg Debugger.
+
+### Added
+
+### Changed
+- Set variable length (stack frames) for showing the callstack ([link](https://docs.hyperdbg.org/commands/debugging-commands/k))
+
 ## [0.13.1.0] - 2025-04-14
 New release of the HyperDbg Debugger.
 

--- a/hyperdbg/hyperhv/code/hooks/ept-hook/ExecTrap.c
+++ b/hyperdbg/hyperhv/code/hooks/ept-hook/ExecTrap.c
@@ -893,9 +893,12 @@ ExecTrapHandleCr3Vmexit(VIRTUAL_MACHINE_STATE * VCpu)
 BOOLEAN
 ExecTrapAddProcessToWatchingList(UINT32 ProcessId)
 {
+    UINT32 Index; // not used
+
     return InsertionSortInsertItem(&g_ExecTrapState.InterceptionProcessIds[0],
                                    &g_ExecTrapState.NumberOfItems,
                                    MAXIMUM_NUMBER_OF_PROCESSES_FOR_USER_KERNEL_EXEC_THREAD,
+                                   &Index,
                                    (UINT64)ProcessId);
 }
 

--- a/hyperdbg/hyperhv/code/vmm/vmx/IdtEmulation.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/IdtEmulation.c
@@ -334,6 +334,7 @@ IdtEmulationHandleExceptionAndNmi(_Inout_ VIRTUAL_MACHINE_STATE *   VCpu,
 
             __vmx_vmread(VMCS_GUEST_RIP, &GuestRip);
             MemoryMapperReadMemorySafe(GuestRip, &TargetMem, sizeof(BYTE));
+
             if (!EptCheckAndHandleBreakpoint(VCpu) || TargetMem == 0xcc)
             {
                 if (!DebuggingCallbackHandleBreakpointException(VCpu->CoreId))
@@ -379,7 +380,23 @@ IdtEmulationHandleExceptionAndNmi(_Inout_ VIRTUAL_MACHINE_STATE *   VCpu,
 
     case EXCEPTION_VECTOR_DEBUG_BREAKPOINT:
 
-        if (!DebuggingCallbackHandleDebugBreakpointException(VCpu->CoreId))
+        //
+        // Check if transparent mode is enabled and if so, then we need to
+        // check whether the this trap flag is set because of intercepting
+        // the result of a system-call or not
+        //
+        if (g_TransparentMode &&
+            TransparentCheckAndHandleAfterSyscallTrapFlags(VCpu,
+                                                           HANDLE_TO_UINT32(PsGetCurrentProcessId()),
+                                                           HANDLE_TO_UINT32(PsGetCurrentThreadId())))
+        {
+            //
+            // Being here means that this #DB was caused by a trap flag of
+            // the system-call in the transparent-mode, so no need to further handle
+            // it (nothing to do)
+            //
+        }
+        else if (!DebuggingCallbackHandleDebugBreakpointException(VCpu->CoreId))
         {
             //
             // It's not because of thread change detection, so re-inject it

--- a/hyperdbg/hyperhv/code/vmm/vmx/MsrHandlers.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/MsrHandlers.c
@@ -124,6 +124,22 @@ MsrHandleRdmsrVmexit(VIRTUAL_MACHINE_STATE * VCpu)
             }
 
             //
+            // The MSR range between 40000000H and 400000F0H is reserved and usually used by hypervisors
+            // when the guest operating system is Windows to indicate the OS identifier
+            //
+            if(g_TransparentMode && (TargetMsr >= RESERVED_MSR_RANGE_LOW && (TargetMsr <= RESERVED_MSR_RANGE_HI)))
+            {
+
+                LogInfo("RDMSR attempts to read from a reserved MSR range. MSR: %x, from: %llx", 
+                    TargetMsr, 
+                    VCpu->LastVmexitRip);
+            
+                EventInjectGeneralProtection();
+
+                return;
+            }
+
+            //
             // Msr is valid
             //
             Msr.Flags = __readmsr(TargetMsr);
@@ -258,6 +274,25 @@ MsrHandleWrmsrVmexit(VIRTUAL_MACHINE_STATE * VCpu)
             break;
 
         default:
+
+            if(g_TransparentMode && (TargetMsr >= RESERVED_MSR_RANGE_LOW && (TargetMsr <= RESERVED_MSR_RANGE_HI)))
+            {
+
+            //
+            // The MSR range between 40000000H and 400000F0H is reserved and usually used by hypervisors
+            // when the guest operating system is Windows to indicate the OS identifier
+            //
+        
+            LogInfo("WRMSR attempts to write to a reserved MSR range. MSR: %x, rax: %llx, rdx: %llx, from: %llx", 
+                TargetMsr,
+                GuestRegs->rax,
+                GuestRegs->rdx,
+                VCpu->LastVmexitRip);
+        
+            EventInjectGeneralProtection();
+            
+            return;
+        }
 
             //
             // Perform the WRMSR

--- a/hyperdbg/hyperhv/code/vmm/vmx/ProtectedHv.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/ProtectedHv.c
@@ -58,6 +58,15 @@ ProtectedHvChangeExceptionBitmapWithIntegrityCheck(VIRTUAL_MACHINE_STATE * VCpu,
     }
 
     //
+    // Check for transparent-mode (masking #DBs and #BPs)
+    //
+    if (g_TransparentMode)
+    {
+        CurrentMask |= 1 << EXCEPTION_VECTOR_DEBUG_BREAKPOINT;
+        CurrentMask |= 1 << EXCEPTION_VECTOR_BREAKPOINT;
+    }
+
+    //
     // Write the final value
     //
     HvWriteExceptionBitmap(CurrentMask);

--- a/hyperdbg/hyperhv/code/vmm/vmx/Vmexit.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/Vmexit.c
@@ -139,6 +139,11 @@ VmxVmexitHandler(_Inout_ PGUEST_REGS GuestRegs)
     }
     case VMX_EXIT_REASON_EXECUTE_RDMSR:
     {
+        //
+        // Handle vm-exit, events, dispatches and perform MSR read
+        //
+        DispatchEventRdmsr(VCpu);
+
         break;
     }
     case VMX_EXIT_REASON_IO_SMI:

--- a/hyperdbg/hyperhv/code/vmm/vmx/Vmexit.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/Vmexit.c
@@ -146,19 +146,19 @@ VmxVmexitHandler(_Inout_ PGUEST_REGS GuestRegs)
 
         break;
     }
-    case VMX_EXIT_REASON_IO_SMI:
-    case VMX_EXIT_REASON_SMI:
-    {
-        LogInfo("VM-exit reason SMM %llx | qual: %llx", ExitReason, VCpu->ExitQualification);
-
-        break;
-    }
     case VMX_EXIT_REASON_EXECUTE_WRMSR:
     {
         //
         // Handle vm-exit, events, dispatches and perform changes
         //
         DispatchEventWrmsr(VCpu);
+
+        break;
+    }
+    case VMX_EXIT_REASON_IO_SMI:
+    case VMX_EXIT_REASON_SMI:
+    {
+        LogInfo("VM-exit reason SMM %llx | qual: %llx", ExitReason, VCpu->ExitQualification);
 
         break;
     }

--- a/hyperdbg/hyperhv/code/vmm/vmx/Vmx.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/Vmx.c
@@ -1035,7 +1035,7 @@ VmxVmresume()
     // prefer to break
     //
 
-    LogError("Err,  in executing VMRESUME , status : 0x%llx, last VM-exit reason: 0x%x",
+    LogError("Err, in executing VMRESUME, status : 0x%llx, last VM-exit reason: 0x%x",
              ErrorCode,
              g_GuestState[KeGetCurrentProcessorNumberEx(NULL)].ExitReason);
 }

--- a/hyperdbg/hyperhv/header/globals/GlobalVariables.h
+++ b/hyperdbg/hyperhv/header/globals/GlobalVariables.h
@@ -69,6 +69,12 @@ BOOLEAN g_IsEptHook2sDetourListInitialized;
 BOOLEAN g_TransparentMode;
 
 /**
+ * @brief State of transparent-mode trap-flags
+ *
+ */
+TRANSPARENT_MODE_TRAP_FLAG_STATE * g_TransparentModeTrapFlagState;
+
+/**
  * @brief Local APIC Base
  *
  */

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -12,30 +12,6 @@
 #pragma once
 
 //////////////////////////////////////////////////
-//				   Functions					//
-//////////////////////////////////////////////////
-
-VOID
-TransparentCPUID(INT32 CpuInfo[], PGUEST_REGS Regs);
-
-BOOLEAN
-TransparentSetTrapFlagAfterSyscall(VIRTUAL_MACHINE_STATE * VCpu,
-                                   UINT32                  ProcessId,
-                                   UINT32                  ThreadId,
-                                   UINT64                  Context);
-
-BOOLEAN
-TransparentCheckAndHandleAfterSyscallTrapFlags(VIRTUAL_MACHINE_STATE * VCpu,
-                                               UINT32                  ProcessId,
-                                               UINT32                  ThreadId);
-
-VOID
-TransparentCallbackHandleAfterSyscall(VIRTUAL_MACHINE_STATE * VCpu,
-                                      UINT32                  ProcessId,
-                                      UINT32                  ThreadId,
-                                      UINT64                  Context);
-
-//////////////////////////////////////////////////
 //				      Locks 	    			//
 //////////////////////////////////////////////////
 
@@ -124,6 +100,19 @@ typedef struct _TRANSPARENT_MODE_PROCESS_THREAD_INFORMATION
 } TRANSPARENT_MODE_PROCESS_THREAD_INFORMATION, *PTRANSPARENT_MODE_PROCESS_THREAD_INFORMATION;
 
 /**
+ * @brief The (optional) context parameters for the transparent-mode
+ *
+ */
+typedef struct _TRANSPARENT_MODE_CONTEXT_PARAMS
+{
+    UINT64 OptionalParam1; // Optional parameter
+    UINT64 OptionalParam2; // Optional parameter
+    UINT64 OptionalParam3; // Optional parameter
+    UINT64 OptionalParam4; // Optional parameter
+
+} TRANSPARENT_MODE_CONTEXT_PARAMS, *PTRANSPARENT_MODE_CONTEXT_PARAMS;
+
+/**
  * @brief The threads that we expect to get the trap flag
  *
  * @details Used for keeping track of the threads that we expect to get the trap flag
@@ -134,5 +123,32 @@ typedef struct _TRANSPARENT_MODE_TRAP_FLAG_STATE
     UINT32                                      NumberOfItems;
     TRANSPARENT_MODE_PROCESS_THREAD_INFORMATION ThreadInformation[MAXIMUM_NUMBER_OF_THREAD_INFORMATION_FOR_TRANSPARENT_MODE_TRAPS];
     UINT64                                      Context[MAXIMUM_NUMBER_OF_THREAD_INFORMATION_FOR_TRANSPARENT_MODE_TRAPS];
+    TRANSPARENT_MODE_CONTEXT_PARAMS             Params[MAXIMUM_NUMBER_OF_THREAD_INFORMATION_FOR_TRANSPARENT_MODE_TRAPS];
 
 } TRANSPARENT_MODE_TRAP_FLAG_STATE, *PTRANSPARENT_MODE_TRAP_FLAG_STATE;
+
+//////////////////////////////////////////////////
+//				   Functions					//
+//////////////////////////////////////////////////
+
+VOID
+TransparentCPUID(INT32 CpuInfo[], PGUEST_REGS Regs);
+
+BOOLEAN
+TransparentSetTrapFlagAfterSyscall(VIRTUAL_MACHINE_STATE *           VCpu,
+                                   UINT32                            ProcessId,
+                                   UINT32                            ThreadId,
+                                   UINT64                            Context,
+                                   TRANSPARENT_MODE_CONTEXT_PARAMS * Params);
+
+BOOLEAN
+TransparentCheckAndHandleAfterSyscallTrapFlags(VIRTUAL_MACHINE_STATE * VCpu,
+                                               UINT32                  ProcessId,
+                                               UINT32                  ThreadId);
+
+VOID
+TransparentCallbackHandleAfterSyscall(VIRTUAL_MACHINE_STATE *           VCpu,
+                                      UINT32                            ProcessId,
+                                      UINT32                            ThreadId,
+                                      UINT64                            Context,
+                                      TRANSPARENT_MODE_CONTEXT_PARAMS * Params);

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -18,6 +18,33 @@
 VOID
 TransparentCPUID(INT32 CpuInfo[], PGUEST_REGS Regs);
 
+BOOLEAN
+TransparentSetTrapFlagAfterSyscall(VIRTUAL_MACHINE_STATE * VCpu,
+                                   UINT32                  ProcessId,
+                                   UINT32                  ThreadId,
+                                   UINT64                  Context);
+
+BOOLEAN
+TransparentCheckAndHandleAfterSyscallTrapFlags(VIRTUAL_MACHINE_STATE * VCpu,
+                                               UINT32                  ProcessId,
+                                               UINT32                  ThreadId);
+
+VOID
+TransparentCallbackHandleAfterSyscall(VIRTUAL_MACHINE_STATE * VCpu,
+                                      UINT32                  ProcessId,
+                                      UINT32                  ThreadId,
+                                      UINT64                  Context);
+
+//////////////////////////////////////////////////
+//				      Locks 	    			//
+//////////////////////////////////////////////////
+
+/**
+ * @brief The lock for modifying list of process/thread for transparent-mode trap flags
+ *
+ */
+volatile LONG TransparentModeTrapListLock;
+
 //////////////////////////////////////////////////
 //				   Definitions					//
 //////////////////////////////////////////////////
@@ -33,6 +60,13 @@ TransparentCPUID(INT32 CpuInfo[], PGUEST_REGS Regs);
  *
  */
 #define RAND_MAX 0x7fff
+
+/**
+ * @brief maximum number of thread/process ids to be allocated for keeping track of
+ * of the trap flag
+ *
+ */
+#define MAXIMUM_NUMBER_OF_THREAD_INFORMATION_FOR_TRANSPARENT_MODE_TRAPS 500
 
 //////////////////////////////////////////////////
 //				   Structures					//
@@ -69,3 +103,36 @@ typedef struct _TRANSPARENCY_PROCESS
     LIST_ENTRY OtherProcesses;
 
 } TRANSPARENCY_PROCESS, *PTRANSPARENCY_PROCESS;
+
+/**
+ * @brief The thread/process information
+ *
+ */
+typedef struct _TRANSPARENT_MODE_PROCESS_THREAD_INFORMATION
+{
+    union
+    {
+        UINT64 asUInt;
+
+        struct
+        {
+            UINT32 ProcessId;
+            UINT32 ThreadId;
+        } Fields;
+    };
+
+} TRANSPARENT_MODE_PROCESS_THREAD_INFORMATION, *PTRANSPARENT_MODE_PROCESS_THREAD_INFORMATION;
+
+/**
+ * @brief The threads that we expect to get the trap flag
+ *
+ * @details Used for keeping track of the threads that we expect to get the trap flag
+ *
+ */
+typedef struct _TRANSPARENT_MODE_TRAP_FLAG_STATE
+{
+    UINT32                                      NumberOfItems;
+    TRANSPARENT_MODE_PROCESS_THREAD_INFORMATION ThreadInformation[MAXIMUM_NUMBER_OF_THREAD_INFORMATION_FOR_TRANSPARENT_MODE_TRAPS];
+    UINT64                                      Context[MAXIMUM_NUMBER_OF_THREAD_INFORMATION_FOR_TRANSPARENT_MODE_TRAPS];
+
+} TRANSPARENT_MODE_TRAP_FLAG_STATE, *PTRANSPARENT_MODE_TRAP_FLAG_STATE;

--- a/hyperdbg/hyperhv/header/vmm/vmx/HypervTlfs.h
+++ b/hyperdbg/hyperhv/header/vmm/vmx/HypervTlfs.h
@@ -273,6 +273,29 @@ enum hv_isolation_type
 #define HV_X64_MSR_TIME_REF_COUNT HV_REGISTER_TIME_REF_COUNT
 #define HV_X64_MSR_REFERENCE_TSC  HV_REGISTER_REFERENCE_TSC
 
+//
+// Define the synthetic timer configuration structure
+//
+typedef struct _HV_X64_MSR_STIMER_CONFIG_CONTENTS
+{
+    union
+    {
+        UINT64 AsUINT64;
+        struct
+        {
+            UINT64 Enable : 1;
+            UINT64 Periodic : 1;
+            UINT64 Lazy : 1;
+            UINT64 AutoEnable : 1;
+            UINT64 ApicVector : 8;
+            UINT64 DirectMode : 1;
+            UINT64 ReservedZ1 : 1;
+            UINT64 SINTx : 4;
+            UINT64 ReservedZ2 : 44;
+        };
+    };
+} HV_X64_MSR_STIMER_CONFIG_CONTENTS, *PHV_X64_MSR_STIMER_CONFIG_CONTENTS;
+
 /* Hyper-V memory host visibility */
 enum hv_mem_host_visibility
 {

--- a/hyperdbg/hyperkd/code/debugger/commands/BreakpointCommands.c
+++ b/hyperdbg/hyperkd/code/debugger/commands/BreakpointCommands.c
@@ -214,6 +214,7 @@ BreakpointRestoreTheTrapFlagOnceTriggered(UINT32 ProcessId, UINT32 ThreadId)
         SuccessfullyStored = InsertionSortInsertItem((UINT64 *)&g_TrapFlagState.ThreadInformation[0],
                                                      &g_TrapFlagState.NumberOfItems,
                                                      MAXIMUM_NUMBER_OF_THREAD_INFORMATION_FOR_TRAPS,
+                                                     &Index, // not used
                                                      ProcThrdInfo.asUInt);
         goto Return;
     }
@@ -282,7 +283,6 @@ BreakpointCheckAndHandleDebugBreakpoint(UINT32 CoreId)
             // stepping routines to work, even if the debugger masks the
             // traps by using 'test trap off', so stepping still works
             //
-
 
             //
             // Handle debug events (breakpoint, traps, hardware debug register when kernel

--- a/hyperdbg/hyperkd/code/debugger/commands/Callstack.c
+++ b/hyperdbg/hyperkd/code/debugger/commands/Callstack.c
@@ -15,6 +15,7 @@
  * @brief Walkthrough the stack
  *
  * @param AddressToSaveFrames
+ * @param FrameCount
  * @param StackBaseAddress
  * @param Size
  * @param Is32Bit
@@ -23,6 +24,7 @@
  */
 BOOLEAN
 CallstackWalkthroughStack(PDEBUGGER_SINGLE_CALLSTACK_FRAME AddressToSaveFrames,
+                          UINT32 *                         FrameCount,
                           UINT64                           StackBaseAddress,
                           UINT32                           Size,
                           BOOLEAN                          Is32Bit)
@@ -63,6 +65,7 @@ CallstackWalkthroughStack(PDEBUGGER_SINGLE_CALLSTACK_FRAME AddressToSaveFrames,
         // Compute the current stack position address
         //
         CurrentStackAddress = StackBaseAddress + (i * AddressMode);
+        *FrameCount         = FrameIndex;
 
         if (!CheckAccessValidityAndSafety(CurrentStackAddress, AddressMode))
         {
@@ -71,7 +74,20 @@ CallstackWalkthroughStack(PDEBUGGER_SINGLE_CALLSTACK_FRAME AddressToSaveFrames,
             //
             // Stack is no longer valid or available to access from here
             //
-            return FALSE;
+            if (FrameIndex == 0)
+            {
+                //
+                // Stack is invalid
+                //
+                return FALSE;
+            }
+            else
+            {
+                //
+                // Stack is invalid, but there are frames that are still valid
+                //
+                return TRUE;
+            }
         }
 
         //

--- a/hyperdbg/hyperkd/code/debugger/kernel-level/Kd.c
+++ b/hyperdbg/hyperkd/code/debugger/kernel-level/Kd.c
@@ -2578,6 +2578,7 @@ KdDispatchAndPerformCommandsFromDebugger(PROCESSOR_DEBUGGING_STATE * DbgState)
                 // Feel the callstack frames the buffers
                 //
                 if (CallstackWalkthroughStack(CallstackFrameBuffer,
+                                              &CallstackPacket->FrameCount,
                                               CallstackPacket->BaseAddress,
                                               CallstackPacket->Size,
                                               CallstackPacket->Is32Bit))

--- a/hyperdbg/hyperkd/header/debugger/commands/Callstack.h
+++ b/hyperdbg/hyperkd/header/debugger/commands/Callstack.h
@@ -17,6 +17,7 @@
 
 BOOLEAN
 CallstackWalkthroughStack(PDEBUGGER_SINGLE_CALLSTACK_FRAME AddressToSaveFrames,
+                          UINT32 *                         FrameCount,
                           UINT64                           StackBaseAddress,
                           UINT32                           Size,
                           BOOLEAN                          Is32Bit);

--- a/hyperdbg/include/SDK/headers/Constants.h
+++ b/hyperdbg/include/SDK/headers/Constants.h
@@ -18,7 +18,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 13
-#define VERSION_PATCH 1
+#define VERSION_PATCH 2
 
 //
 // Example of __DATE__ string: "Jul 27 2012"

--- a/hyperdbg/include/components/optimizations/code/InsertionSort.c
+++ b/hyperdbg/include/components/optimizations/code/InsertionSort.c
@@ -16,12 +16,14 @@
  *
  * @param ArrayPtr
  * @param NumberOfItems
+ * @param MaxNumOfItems
+ * @param Index
  * @param Key
  *
  * @return BOOLEAN
  */
 BOOLEAN
-InsertionSortInsertItem(UINT64 ArrayPtr[], UINT32 * NumberOfItems, UINT32 MaxNumOfItems, UINT64 Key)
+InsertionSortInsertItem(UINT64 ArrayPtr[], UINT32 * NumberOfItems, UINT32 MaxNumOfItems, UINT32 * Index, UINT64 Key)
 {
     UINT32 Idx;
 
@@ -45,6 +47,7 @@ InsertionSortInsertItem(UINT64 ArrayPtr[], UINT32 * NumberOfItems, UINT32 MaxNum
         Idx           = Idx - 1;
     }
     ArrayPtr[Idx] = Key;
+    *Index        = Idx;
     (*NumberOfItems)++;
 
     //

--- a/hyperdbg/include/components/optimizations/code/OptimizationsExamples.c
+++ b/hyperdbg/include/components/optimizations/code/OptimizationsExamples.c
@@ -30,12 +30,12 @@ OptimizationExampleInsertionSortAndBinarySearch()
     UINT32 NumberOfItems         = 0;
     UINT32 Index;
 
-    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, 12);
-    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, 11);
-    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, 13);
-    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, 5);
-    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, 6);
-    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, 8);
+    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, &Index, 12);
+    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, &Index, 11);
+    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, &Index, 13);
+    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, &Index, 5);
+    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, &Index, 6);
+    InsertionSortInsertItem(Arr, &NumberOfItems, MAX_NUM_OF_ARRAY, &Index, 8);
 
     //
     // Search for item equal to 15

--- a/hyperdbg/include/components/optimizations/header/InsertionSort.h
+++ b/hyperdbg/include/components/optimizations/header/InsertionSort.h
@@ -16,7 +16,7 @@
 //////////////////////////////////////////////////
 
 BOOLEAN
-InsertionSortInsertItem(UINT64 ArrayPtr[], UINT32 * NumberOfItems, UINT32 MaxNumOfItems, UINT64 Key);
+InsertionSortInsertItem(UINT64 ArrayPtr[], UINT32 * NumberOfItems, UINT32 MaxNumOfItems, UINT32 * Index, UINT64 Key);
 
 BOOLEAN
 InsertionSortDeleteItem(UINT64 ArrayPtr[], UINT32 * NumberOfItems, UINT32 Index);

--- a/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/k.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/k.cpp
@@ -55,8 +55,8 @@ CommandKHelp()
 VOID
 CommandK(vector<CommandToken> CommandTokens, string Command)
 {
-    UINT64  BaseAddress    = NULL;  // Null base address means current RSP register
-    UINT32  Length         = 0x100; // Default length
+    UINT64  BaseAddress    = NULL;      // Null base address means current RSP register
+    UINT32  Length         = PAGE_SIZE; // Default length
     BOOLEAN IsFirstCommand = TRUE;
     BOOLEAN IsNextBase     = FALSE;
     BOOLEAN IsNextLength   = FALSE;
@@ -81,11 +81,11 @@ CommandK(vector<CommandToken> CommandTokens, string Command)
     //
     if (g_IsRunningInstruction32Bit)
     {
-        Length = 0x100;
+        Length = PAGE_SIZE;
     }
     else
     {
-        Length = 0x200;
+        Length = PAGE_SIZE * 2;
     }
 
     for (auto Section : CommandTokens)

--- a/hyperdbg/libhyperdbg/code/debugger/misc/readmem.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/misc/readmem.cpp
@@ -53,7 +53,7 @@ HyperDbgReadMemory(UINT64                              TargetAddress,
     //
     if (!g_IsSerialConnectedToRemoteDebuggee)
     {
-        //   AssertShowMessageReturnStmt(g_DeviceHandle, ASSERT_MESSAGE_DRIVER_NOT_LOADED, AssertReturnFalse);
+        AssertShowMessageReturnStmt(g_DeviceHandle, ASSERT_MESSAGE_DRIVER_NOT_LOADED, AssertReturnFalse);
     }
 
     //
@@ -119,9 +119,9 @@ HyperDbgReadMemory(UINT64                              TargetAddress,
 
         if (!Status)
         {
-            //  ShowMessages("ioctl failed with code 0x%x\n", GetLastError());
+            ShowMessages("ioctl failed with code 0x%x\n", GetLastError());
             std::free(MemReadRequest);
-            //  return FALSE;
+            return FALSE;
         }
     }
 
@@ -352,11 +352,10 @@ HyperDbgShowMemoryOrDisassemble(DEBUGGER_SHOW_MEMORY_STYLE   Style,
         //
         if (ReturnedLength != 0)
         {
-            UCHAR * Buffer2 = (UCHAR *)"\x48\x3d\x48\x40\x40\x00";
             HyperDbgDisassembler64(
                 Buffer,
                 Address,
-                6,
+                ReturnedLength,
                 0,
                 FALSE,
                 NULL);

--- a/hyperdbg/libhyperdbg/code/debugger/misc/readmem.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/misc/readmem.cpp
@@ -53,7 +53,7 @@ HyperDbgReadMemory(UINT64                              TargetAddress,
     //
     if (!g_IsSerialConnectedToRemoteDebuggee)
     {
-        AssertShowMessageReturnStmt(g_DeviceHandle, ASSERT_MESSAGE_DRIVER_NOT_LOADED, AssertReturnFalse);
+        //   AssertShowMessageReturnStmt(g_DeviceHandle, ASSERT_MESSAGE_DRIVER_NOT_LOADED, AssertReturnFalse);
     }
 
     //
@@ -119,9 +119,9 @@ HyperDbgReadMemory(UINT64                              TargetAddress,
 
         if (!Status)
         {
-            ShowMessages("ioctl failed with code 0x%x\n", GetLastError());
+            //  ShowMessages("ioctl failed with code 0x%x\n", GetLastError());
             std::free(MemReadRequest);
-            return FALSE;
+            //  return FALSE;
         }
     }
 
@@ -352,10 +352,11 @@ HyperDbgShowMemoryOrDisassemble(DEBUGGER_SHOW_MEMORY_STYLE   Style,
         //
         if (ReturnedLength != 0)
         {
+            UCHAR * Buffer2 = (UCHAR *)"\x48\x3d\x48\x40\x40\x00";
             HyperDbgDisassembler64(
                 Buffer,
                 Address,
-                ReturnedLength,
+                6,
                 0,
                 FALSE,
                 NULL);


### PR DESCRIPTION
## [0.13.2.0] - 2025-05-26
New release of the HyperDbg Debugger.

### Added
- Intercepting system-call return results using the TRAP flag for the transparent-mode
- Added optional parameters and context for the transparent-mode system-call return interceptions

### Changed
- Set variable length (stack frames) for showing the callstack ([link](https://docs.hyperdbg.org/commands/debugging-commands/k))
- Fixed VMCS layout corruption due to NMI injection (VMRESUME 0x7 error) in nested-virtualization on Meteor Lake processors
- Restore RDMSR handler for VM-exits