### PR TITLE
Windows system call transparency

### DIFF
--- a/hyperdbg/hyperhv/code/hooks/syscall-hook/SsdtHook.c
+++ b/hyperdbg/hyperhv/code/hooks/syscall-hook/SsdtHook.c
@@ -60,9 +60,9 @@ SyscallHookGetKernelBase(PULONG ImageSize)
 
     if (NT_SUCCESS(Status))
     {
-        ModuleBase = SystemInfoBuffer->Module.ImageBase;
+        ModuleBase = SystemInfoBuffer->Module[1].ImageBase;
         if (ImageSize)
-            *ImageSize = SystemInfoBuffer->Module.ImageSize;
+            *ImageSize = SystemInfoBuffer->Module[1].ImageSize;
     }
     else
     {

--- a/hyperdbg/hyperhv/code/interface/Dispatch.c
+++ b/hyperdbg/hyperhv/code/interface/Dispatch.c
@@ -966,6 +966,7 @@ DispatchEventHiddenHookExecCc(VIRTUAL_MACHINE_STATE * VCpu, PVOID Context)
     if (g_TransparentMode) 
     {
         TransparentHandleSystemCallHook(VCpu);
+        g_Callbacks.VmmCallbackTriggerEvents = NULL;
     }
 
     //

--- a/hyperdbg/hyperhv/code/interface/Dispatch.c
+++ b/hyperdbg/hyperhv/code/interface/Dispatch.c
@@ -961,6 +961,14 @@ DispatchEventHiddenHookExecCc(VIRTUAL_MACHINE_STATE * VCpu, PVOID Context)
     BOOLEAN PostEventTriggerReq = FALSE;
 
     //
+    // In Transparency mode a hidden hook for the system call handler gets inserted
+    //
+    if (g_TransparentMode) 
+    {
+        TransparentHandleSystemCallHook(VCpu);
+    }
+
+    //
     // Triggering the pre-event (This command only support the
     // pre-event, the post-event doesn't make sense in this command)
     //

--- a/hyperdbg/hyperhv/code/transparency/Transparency.c
+++ b/hyperdbg/hyperhv/code/transparency/Transparency.c
@@ -1217,14 +1217,16 @@ ReturnResult:
  *          The revealing list entries are removed and overwritten, but the memory buffer is not reallocated, so
  *          it is possible to still detect that some tampering was done from the user space
  *
- * @param ptr The pointer to a valid read/writable SYSTEM_MODULE_INFORMATION memory buffer 
+ * @param Ptr The pointer to a valid read/writable SYSTEM_MODULE_INFORMATION memory buffer 
+ * @param VirualAddress A pointer to a user-mode virual address
+ * @param BufferSize Size of the user-mode buffer
  *
  * @return BOOLEAN
  */
 BOOLEAN
-TransparentHandleModuleInformationQuery(PVOID ptr, UINT64 virtualAddress, UINT32 bufferSize)
+TransparentHandleModuleInformationQuery(PVOID Ptr, UINT64 VirtualAddress, UINT32 BufferSize)
 {
-    PSYSTEM_MODULE_INFORMATION StructBuf = (PSYSTEM_MODULE_INFORMATION)ptr;
+    PSYSTEM_MODULE_INFORMATION StructBuf = (PSYSTEM_MODULE_INFORMATION)Ptr;
     PSYSTEM_MODULE_ENTRY ModuleList = StructBuf->Module;
 
     //
@@ -1258,7 +1260,7 @@ TransparentHandleModuleInformationQuery(PVOID ptr, UINT64 virtualAddress, UINT32
         }
 
     }
-    if(!MemoryMapperWriteMemorySafeOnTargetProcess(virtualAddress, ptr, bufferSize))
+    if(!MemoryMapperWriteMemorySafeOnTargetProcess(VirtualAddress, Ptr, BufferSize))
     { 
         return FALSE;
     }
@@ -1266,12 +1268,14 @@ TransparentHandleModuleInformationQuery(PVOID ptr, UINT64 virtualAddress, UINT32
 }
 
 
-//**
+/**
  * @brief Handle the request for SystemProcessInformation
  * 
  * @details This function removes entries from a list of active system processes that could reveal the presence of hypervisors
  *
- * @param ptr The pointer to a valid read/writable SYSTEM_PROCESS_INFORMATION memory buffer 
+ * @param Params        Preset transparent callback params that contain:
+                        in OptionalParam2 a pointer to a valid read/writable memory buffer that contains a SYSTEM_PROCESS_INFORMATION structure
+                        in OptionalParam3 max size in bytes of the allocated buffer
  *
  * @return BOOLEAN
  */

--- a/hyperdbg/hyperhv/code/vmm/vmx/Hv.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/Hv.c
@@ -115,10 +115,10 @@ HvHandleCpuid(VIRTUAL_MACHINE_STATE * VCpu)
             CpuInfo[0] = '0#vH'; // Hv#0
             CpuInfo[1] = CpuInfo[2] = CpuInfo[3] = 0;
         }
-        else 
-        {
-            TransparentCPUID(CpuInfo, Regs);
-        }
+    }
+    else 
+    {
+        TransparentCPUID(CpuInfo, Regs);
     }
 
     //

--- a/hyperdbg/hyperhv/header/hooks/Hooks.h
+++ b/hyperdbg/hyperhv/header/hooks/Hooks.h
@@ -143,33 +143,6 @@ NTSTATUS(*NtCreateFileOrig)
     PVOID              EaBuffer,
     ULONG              EaLength);
 
-/**
- * @brief Windows System call values that are intercepted by transparency mode
- *
-*/
-
-enum _WIN_SYSTEM_CALLS
-{
-    SysNtQuerySystemInformation        = 0x0036,
-    SysNtQuerySystemInformationEx      = 0x0162, // On 22H2, changes on each windows version
-    
-    SysNtQueryVolumeInformationFile = 0x0049,
-    SysNtSystemDebugControl         = 0x01bf, // On 22H2, changes on each windows version
-    SysNtQueryAttributesFile        = 0x003d,
-    SysNtOpenDirectoryObject        = 0x0058,
-    SysNtQueryDirectoryObject       = 0x0114, // On 22H2, changes on each windows version
-    SysNtQueryInformationProcess    = 0x0019,
-    SysNtSetInformationProcess      = 0x001c,
-    SysNtQueryInformationThread     = 0x0025,
-    SysNtSetInformationThread       = 0x000d,
-    SysNtOpenFile                   = 0x0033,
-    SysNtOpenKey                    = 0x0012,
-    SysNtOpenKeyEx                  = 0x0121,
-    SysNtQueryValueKey              = 0x0017,
-    SysNtOpenKeyTransacted          = 0x0122, // On 22H2, changes on each windows version
-    SysNtEnumerateKey               = 0x0032,
-
-};
 //////////////////////////////////////////////////
 //		     Syscall Hooks Functions			//
 //////////////////////////////////////////////////

--- a/hyperdbg/hyperhv/header/hooks/Hooks.h
+++ b/hyperdbg/hyperhv/header/hooks/Hooks.h
@@ -103,7 +103,7 @@ typedef struct _SYSTEM_MODULE_ENTRY
 typedef struct _SYSTEM_MODULE_INFORMATION
 {
     ULONG               Count;
-    SYSTEM_MODULE_ENTRY Module;
+    SYSTEM_MODULE_ENTRY Module[1];
 
 } SYSTEM_MODULE_INFORMATION, *PSYSTEM_MODULE_INFORMATION;
 
@@ -113,8 +113,12 @@ typedef struct _SYSTEM_MODULE_INFORMATION
  */
 typedef enum _SYSTEM_INFORMATION_CLASS
 {
-    SystemModuleInformation         = 11,
-    SystemKernelDebuggerInformation = 35
+    SystemProcessInformation            = 0x05,
+    SystemExtendedProcessInformation    = 0x39,
+    SystemFullProcessInformation        = 0x94,
+    SystemModuleInformation             = 0x0B,
+    SystemKernelDebuggerInformation     = 0x23,
+    SystemCodeIntegrityInformation      = 0x67,
 } SYSTEM_INFORMATION_CLASS,
     *PSYSTEM_INFORMATION_CLASS;
 
@@ -138,6 +142,28 @@ NTSTATUS(*NtCreateFileOrig)
     PVOID              EaBuffer,
     ULONG              EaLength);
 
+/**
+ * @brief Windows System call values that are intercepted by transparency mode
+ *
+*/
+
+enum _WIN_SYSTEM_CALLS
+{
+    NtQuerySystemInformation        = 0x0036,
+    NtQuerySystemInformationEx      = 0x0162, // On 22H2, changes on each windows version
+    
+    SysNtQueryVolumeInformationFile = 0x0049,
+    SysNtSystemDebugControl         = 0x01bf, // On 22H2, changes on each windows version
+    SysNtQueryAttributesFile        = 0x003d,
+    SysNtOpenDirectoryObject        = 0x0058,
+    SysNtQueryDirectoryObject       = 0x0114, // On 22H2, changes on each windows version
+    SysNtQueryInformationProcess    = 0x0019,
+    SysNtSetInformationProcess      = 0x001c,
+    SysNtQueryInformationThread     = 0x0025,
+    SysNtSetInformationThread       = 0x000d,
+    SysNtOpenFile                   = 0x0033
+
+};
 //////////////////////////////////////////////////
 //		     Syscall Hooks Functions			//
 //////////////////////////////////////////////////

--- a/hyperdbg/hyperhv/header/hooks/Hooks.h
+++ b/hyperdbg/hyperhv/header/hooks/Hooks.h
@@ -119,6 +119,7 @@ typedef enum _SYSTEM_INFORMATION_CLASS
     SystemModuleInformation             = 0x0B,
     SystemKernelDebuggerInformation     = 0x23,
     SystemCodeIntegrityInformation      = 0x67,
+    SystemFirmwareTableInformation      = 0x4C,
 } SYSTEM_INFORMATION_CLASS,
     *PSYSTEM_INFORMATION_CLASS;
 
@@ -161,7 +162,11 @@ enum _WIN_SYSTEM_CALLS
     SysNtSetInformationProcess      = 0x001c,
     SysNtQueryInformationThread     = 0x0025,
     SysNtSetInformationThread       = 0x000d,
-    SysNtOpenFile                   = 0x0033
+    SysNtOpenFile                   = 0x0033,
+    SysNtOpenKey                    = 0x0012,
+    SysNtOpenKeyEx                  = 0x0121,
+    SysNtQueryValueKey              = 0x0017,
+    SysNtOpenKeyTransacted          = 0x0122, // On 22H2, changes on each windows version
 
 };
 //////////////////////////////////////////////////

--- a/hyperdbg/hyperhv/header/hooks/Hooks.h
+++ b/hyperdbg/hyperhv/header/hooks/Hooks.h
@@ -150,8 +150,8 @@ NTSTATUS(*NtCreateFileOrig)
 
 enum _WIN_SYSTEM_CALLS
 {
-    NtQuerySystemInformation        = 0x0036,
-    NtQuerySystemInformationEx      = 0x0162, // On 22H2, changes on each windows version
+    SysNtQuerySystemInformation        = 0x0036,
+    SysNtQuerySystemInformationEx      = 0x0162, // On 22H2, changes on each windows version
     
     SysNtQueryVolumeInformationFile = 0x0049,
     SysNtSystemDebugControl         = 0x01bf, // On 22H2, changes on each windows version
@@ -167,6 +167,7 @@ enum _WIN_SYSTEM_CALLS
     SysNtOpenKeyEx                  = 0x0121,
     SysNtQueryValueKey              = 0x0017,
     SysNtOpenKeyTransacted          = 0x0122, // On 22H2, changes on each windows version
+    SysNtEnumerateKey               = 0x0032,
 
 };
 //////////////////////////////////////////////////

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -168,6 +168,63 @@ typedef struct _SYSTEM_PROCESS_INFORMATION {
     LARGE_INTEGER Reserved7[6];
 } SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
 
+static const PWCHAR TRANSPARENT_LEGIT_DEVICE_ID_VENDOR_STRINGS_WCHAR[] = {
+    L"",
+
+    L"VEN_8086",  // Intel  
+    L"VEN_10DE",  // NVIDIA  
+    L"VEN_1002",  // AMD  
+    L"VEN_10EC",  // Realtek
+
+};
+
+static const PWCHAR TRANSPARENT_LEGIT_VENDOR_STRINGS_WCHAR[] = {
+    L"",
+
+    L"ASUS",
+    L"ASUSTeK Computer INC.",
+    L"ASUSTek",
+    L"ASUSTEK COMPUTER INC.",
+
+    // MSI
+    L"Micro-Star International Co., Ltd.",
+    L"MSI",
+    L"MICRO-STAR INTERNATIONAL CO., LTD",
+
+    // Gigabyte
+    L"Gigabyte Technology Co., Ltd.",
+    L"GIGABYTE",
+    L"Gigabyte Technology",
+
+    // ASRock
+    L"ASRock",
+    L"ASRock Incorporation",
+    L"ASRock Inc.",
+
+    // Dell
+    L"Dell Inc.",
+    L"DELL",
+    L"Dell Computer Corporation",
+
+    // HP
+    L"Hewlett-Packard",
+    L"Hewlett Packard",
+    L"HP",
+    L"HP Inc.",
+
+    // Lenovo
+    L"LENOVO",
+    L"Lenovo Group Limited",
+
+    // Intel
+    L"Intel Corporation",
+    L"Intel",
+
+    // EVGA
+    L"EVGA Corporation",
+    L"EVGA",
+};
+
 /**
  * @brief A list of common Hypervisor specific process executables
  *
@@ -235,6 +292,7 @@ static const PWCH HV_Processes[] = {
  */
 static const PCHAR HV_DRIVER[] = {
     "hyperkd",
+    "hyperhv",
 
     //
     // Drivers from VBox
@@ -329,7 +387,6 @@ static const PWCH HV_FILES[] = {
         L"VMWare",
 
 
-
         //
         // VirtualBox Files
         //
@@ -391,34 +448,94 @@ static const PWCH HV_DIRS[] = {
     L"Virtio-Win",
     L"qemu-ga",
     L"SPICE Guest Tools",
-    L"VMWare",
+    L"VMware",
+    L"VMWARE",
     L"virtualbox guest additions",
+    L"VirtualBox Guest Additions",
 };
 
-/**
- * @brief A list of common Hypervisor firmware entries
- * 
- * @details The list contains both a normal and uppercase versions of the entries, for better compatibility
- *
- */
-static const PWCH HV_FIRM_NAMES[] = {
-    "VMWARE",
-    "VMware",
-    "VS2005R2",
-    "VirtualBox",
-    "VIRTUALBOX",
-    "Oracle",
-    "ORACLE",
-    "Innotek",
-    "INNOTEK",
+static const PWCH HV_REGKEYS[] = {
+    //
+    // PCI device vendor id's
+    //
+    L"VEN_80EE",
+    L"VEN_15AD",
+    L"VEN_5333",
+
+    //
+    // VMWare
+    //
+    L"VMware Tools",
+    L"VMware, Inc.",
+    L"vmusbmouse",
+    L"VMware",
+    L"VMWARE",
+    L"vmdebug",
+    L"vmmouse",
+    L"VMTools",
+    L"VMMEMCTL",
+    L"vmware tools",
+    L"VMW0001",
+    L"VMW0002",
+    L"VMW0003",
+
+    L"sandbox",
+    L"Sandboxie",
+
+    //
+    // VirtualBox
+    //
+    L"VirtualBox Guest Additions",
+    L"VBOX__",
+    L"VBoxGuest",
+    L"VBoxMouse",
+    L"VBoxService",
+    L"VBoxSF",
+    L"VBoxVideo",
+    L"VIRTUALBOX",
+    L"SUN MICROSYSTEMS",
+    L"VBOXVER",
+    L"VBOXAPIC",
+    L"INNOTEK GMBH",
+
+    //
+    // QEMU
+    //
+    L"qemu-ga",
+    L"SPICE Guest Tools",
+
+    //
+    // VPC
+    //
+    L"vpcbus",
+    L"vpc-s3",
+    L"vpcuhub",
+    L"msvmmouf",
+    L"Wine",
+    L"xen",
+    L"VIRTUAL MACHINE",
+    L"GOOGLE COMPUTE ENGINE",
+    L"sandbox",
+    L"Sandboxie",
+
+    //
+    // KVM
+    //
+    L"vioscsi",
+    L"viostor",
+    L"VirtIO-FS Service",
+    L"VirtioSerial",
+    L"BALLOON",
+    L"BalloonService",
+    L"netkvm",
+
 };
 
-/**
- * @brief A list of Registry keys that might contain indetifiable hypervisor vendor data
- * 
- * @details The keys are spread out in the registry with different paths, where only the final key name is matched
- *
- */
+//
+// @brief A list of registry keys which might contain hypervisor vendor information in their data
+// 
+// NOTE: This is not a complete list, there are a lot of generic keys that also can have the identifiable data
+//
 static const PWCH TRANSPARENT_DETECTABLE_REGISTRY_KEYS[] = {
     L"Identifier",
     L"SystemBiosVersion",
@@ -433,29 +550,31 @@ static const PWCH TRANSPARENT_DETECTABLE_REGISTRY_KEYS[] = {
     L"DisplayName",
     L"ProviderName",
     L"Device Description",
-
+    L"BIOSVendor",
+    L"DriverDesc",
+    L"InfSection",
+    L"Service",
+    L"0",
+    L"1",
+    L"00000000",
 };
 
 /**
- * @brief A list of Registry keys speciffic indetifiable hypervisor vendors
+ * @brief A list of common Hypervisor firmware entries
  * 
+ * @details The list contains both a normal and uppercase versions of the entries, for better compatibility
  *
  */
-static const PWCH HV_REGKEYS[] = {
-    L"VMware Tools",
-    L"qemu-ga",
-    L"SPICE Guest Tools",
-    L"VMware",
-    L"VMWARE",
-    L"VEN_15A",
-    L"VMware, Inc.",
-    L"INNOTEK GMBH",
-    L"VIRTUALBOX",
-    L"SUN MICROSYSTEMS",
-    L"VBOXVER",
-    L"VIRTUAL MACHINE",
-    L"GOOGLE COMPUTE ENGINE",
-    L"VBOXAPIC",
+static const PCHAR HV_FIRM_NAMES[] = {
+    "VMWARE",
+    "VMware",
+    "VS2005R2",
+    "VirtualBox",
+    "VIRTUALBOX",
+    "Oracle",
+    "ORACLE",
+    "Innotek",
+    "INNOTEK",
 };
 //////////////////////////////////////////////////
 //				   Functions					//
@@ -493,6 +612,9 @@ VOID
 TransparentHandleNtQueryAttributesFileSyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
 VOID
+TransparentHandleNtSystemDebugControlSyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
+VOID
 TransparentHandleNtOpenDirectoryObjectSyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
 VOID
@@ -506,6 +628,9 @@ TransparentHandleNtOpenKeySyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
 VOID
 TransparentHandleNtQueryValueKeySyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
+VOID
+TransparentHandleNtEnumerateKeySyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
 UINT32
 TransparentGetRand();

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -425,5 +425,11 @@ TransparentHandleSystemCallHook(VIRTUAL_MACHINE_STATE* VCpu);
 VOID
 TransparentHandleNtQuerySystemInformationSyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
+VOID
+TransparentHandleNtQueryAttributesFileSyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
+VOID
+TransparentHandleNtOpenDirectoryObjectSyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
 UINT32
 TransparentGetRand();

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -127,6 +127,272 @@ typedef struct _TRANSPARENT_MODE_TRAP_FLAG_STATE
 
 } TRANSPARENT_MODE_TRAP_FLAG_STATE, *PTRANSPARENT_MODE_TRAP_FLAG_STATE;
 
+/**
+ * @brief System Information for Code Integrity
+ *
+ */
+typedef struct _SYSTEM_CODEINTEGRITY_INFORMATION
+{
+    ULONG Length;
+    ULONG CodeIntegrityOptions;
+
+} SYSTEM_CODEINTEGRITY_INFORMATION, *PSYSTEM_CODEINTEGRITY_INFORMATION;
+
+/**
+ * @brief System Information for running processes
+ *
+ */
+typedef struct _SYSTEM_PROCESS_INFORMATION {
+    ULONG NextEntryOffset;
+    ULONG NumberOfThreads;
+    BYTE Reserved1[48];
+    UNICODE_STRING ImageName;
+    KPRIORITY BasePriority;
+    HANDLE UniqueProcessId;
+    PVOID Reserved2;
+    ULONG HandleCount;
+    ULONG SessionId;
+    PVOID Reserved3;
+    SIZE_T PeakVirtualSize;
+    SIZE_T VirtualSize;
+    ULONG Reserved4;
+    SIZE_T PeakWorkingSetSize;
+    SIZE_T WorkingSetSize;
+    PVOID Reserved5;
+    SIZE_T QuotaPagedPoolUsage;
+    PVOID Reserved6;
+    SIZE_T QuotaNonPagedPoolUsage;
+    SIZE_T PagefileUsage;
+    SIZE_T PeakPagefileUsage;
+    SIZE_T PrivatePageCount;
+    LARGE_INTEGER Reserved7[6];
+} SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
+
+/**
+ * @brief A list of common Hypervisor specific process executables
+ *
+ */
+static const PWCH HV_Processes[] = {
+    L"hyperdbg-cli.exe",
+    L"vboxservice.exe",
+    L"vmsrvc.exe",
+    L"xenservice.exe",
+    L"vm3dservice.exe",
+    L"VGAuthService.exe",
+    L"vmtoolsd.exe",
+    L"vdagent.exe",
+    L"vdservice.exe",
+    L"qemuwmi.exe",
+    L"vboxtray.exe",
+    L"VBoxControl.exe",
+    L"VGAuthService.exe",
+
+    //
+    // Common Debugging Tools
+    //
+    L"ollydbg.exe",
+    L"ollyice.exe",
+    L"ProcessHacker.exe",
+    L"tcpview.exe",
+    L"autoruns.exe",
+    L"autorunsc.exe",
+    L"filemon.exe",
+    L"procmon.exe",
+    L"regmon.exe",
+    L"procexp.exe",
+    L"idaq.exe",
+    L"idaq64.exe",
+    L"ImmunityDebugger.exe",
+    L"Wireshark.exe",
+    L"dumpcap.exe",
+    L"HookExplorer.exe",
+    L"ImportREC.exe",
+    L"PETools.exe",
+    L"LordPE.exe",
+    L"SysInspector.exe",
+    L"proc_analyzer.exe",
+    L"sysAnalyzer.exe",
+    L"sniff_hit.exe",
+    L"windbg.exe",
+    L"joeboxcontrol.exe",
+    L"joeboxserver.exe",
+    L"ResourceHacker.exe",
+    L"x32dbg.exe",
+    L"x64dbg.exe",
+    L"Fiddler.exe",
+    L"httpdebugger.exe",
+    L"cheatengine-i386.exe",
+    L"cheatengine-x86_64.exe",
+    L"cheatengine-x86_64-SSE4-AVX2.exe",
+    L"frida-helper-32.exe",
+    L"frida-helper-64.exe"
+
+};
+
+/**
+ * @brief A list of common Hypervisor specific drivers
+ *
+ */
+static const PCHAR HV_DRIVER[] = {
+    "hyperkd",
+
+    //
+    // Drivers from VBox
+    //
+
+    "VBoxGuest",
+    "VBoxMouse",
+    "VBoxSF",
+
+    //
+    // Drivers from VMWare Tools
+    //
+
+    "vmrawdsk",
+    "giappdef",
+    "glxgi",
+    "vm3dmp",
+    "vm3dmp_loader",
+    "vm3dmp-debug",
+    "vm3dmp-stats",
+    "vmxnet3",
+    "vmxnet",
+    "vnetWFP",
+    "vnetflt",
+    "vsepflt",
+    "pvscsi",
+    "vmmemctl",
+    "vmhgfs",
+    "vmusbmouse",
+    "vmmouse",
+    "vmaudio",
+    "vmci",
+    "vsock",
+
+    //
+    // Hyper-V Drivers
+    //
+
+    "VMBusHID",
+    "vmbus",
+    "vmgid",
+    "IndirectKmd",
+    "HyperVideo",
+    "hyperkbd",
+
+};
+
+/**
+ * @brief A list of common Hypervisor specific files
+ *
+ */
+static const PWCH HV_FILES[] = {
+        //
+        // Hyperdbg Files
+        //
+        L"hyperhv",
+        L"hyperkd"
+        L"hyperlog",
+        L"libhyperdbg",
+
+
+
+        //
+        // VMWare Files
+        //
+        L"vmmouse.sys",
+        L"vmusbmouse.sys",
+        L"vm3dgl.dll",
+        L"vmdum.dll",
+        L"VmGuestLibJava.dll",
+        L"vm3dver.dll",
+        L"vmtray.dll",
+        L"VMToolsHook.dll",
+        L"vmGuestLib.dll",
+        L"vmhgfs.dll",
+        L"vmhgfs.sys",
+        L"vm3dum64_loader.dll",
+        L"vm3dum64_10.dll",
+        L"vmnet.sys",
+        L"vmusb.sys",
+        L"vm3dmp.sys",
+        L"vmci.sys",
+        L"vmmemctl.sys",
+        L"vmx86.sys",
+        L"vmrawdsk.sys",
+        L"vmkdb.sys",
+        L"vmnetuserif.sys",
+        L"vmnetadapter.sys",
+        L"VMware Tools",
+        L"VMWare",
+
+
+
+        //
+        // VirtualBox Files
+        //
+        L"VBoxMouse.sys",
+        L"VBoxGuest.sys",
+        L"VBoxSF.sys",
+        L"VBoxVideo.sys",
+        L"vboxoglpackspu.dll",
+        L"vboxoglpassthroughspu.dll",
+        L"vboxservice.exe",
+        L"vboxoglcrutil.dll",
+        L"vboxdisp.dll",
+        L"vboxhook.dll",
+        L"vboxmrxnp.dll",
+        L"vboxogl.dll",
+        L"vboxtray.exe",
+        L"VBoxControl.exe",
+        L"vboxoglerrorspu.dll",
+        L"vboxoglfeedbackspu.dll",
+        L"vboxoglarrayspu.dll",
+        L"vboxmrxnp.dll",
+        L"virtualbox guest additions",
+
+        //
+        // KVM files
+        //
+        L"balloon.sys",
+        L"netkvm.sys",
+        L"pvpanic.sys",
+        L"viofs.sys",
+        L"viogpudo.sys",
+        L"vioinput.sys",
+        L"viorng.sys",
+        L"vioscsi.sys",
+        L"vioser.sys",
+        L"viostor.sys",
+
+        //
+        // VPC files
+        //
+        L"vmsrvc.sys",
+        L"vmusrvc.sys",
+        L"vmsrvc.exe",
+        L"vmusrvc.exe",
+        L"vpc-s3.sys",
+        L"Virtio-Win",
+        
+        L"qemu-ga",
+        L"SPICE Guest Tools",
+};
+
+/**
+ * @brief A list of common Hypervisor specific directories
+ *
+ */
+static const PWCH HV_DIRS[] = {
+    L"hyperhv",
+    L"VMware Tools",
+    L"Virtio-Win",
+    L"qemu-ga",
+    L"SPICE Guest Tools",
+    L"VMWare",
+    L"virtualbox guest additions",
+};
+
 //////////////////////////////////////////////////
 //				   Functions					//
 //////////////////////////////////////////////////
@@ -155,3 +421,9 @@ TransparentCallbackHandleAfterSyscall(VIRTUAL_MACHINE_STATE *           VCpu,
 
 VOID
 TransparentHandleSystemCallHook(VIRTUAL_MACHINE_STATE* VCpu);
+
+VOID
+TransparentHandleNtQuerySystemInformationSyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
+UINT32
+TransparentGetRand();

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -301,7 +301,9 @@ static const PWCH HV_FILES[] = {
         // VMWare Files
         //
         L"vmmouse.sys",
+        L"Vmmouse.sys",
         L"vmusbmouse.sys",
+        L"Vmusbmouse.sys",
         L"vm3dgl.dll",
         L"vmdum.dll",
         L"VmGuestLibJava.dll",
@@ -393,6 +395,68 @@ static const PWCH HV_DIRS[] = {
     L"virtualbox guest additions",
 };
 
+/**
+ * @brief A list of common Hypervisor firmware entries
+ * 
+ * @details The list contains both a normal and uppercase versions of the entries, for better compatibility
+ *
+ */
+static const PWCH HV_FIRM_NAMES[] = {
+    "VMWARE",
+    "VMware",
+    "VS2005R2",
+    "VirtualBox",
+    "VIRTUALBOX",
+    "Oracle",
+    "ORACLE",
+    "Innotek",
+    "INNOTEK",
+};
+
+/**
+ * @brief A list of Registry keys that might contain indetifiable hypervisor vendor data
+ * 
+ * @details The keys are spread out in the registry with different paths, where only the final key name is matched
+ *
+ */
+static const PWCH TRANSPARENT_DETECTABLE_REGISTRY_KEYS[] = {
+    L"Identifier",
+    L"SystemBiosVersion",
+    L"VideoBiosVersion",
+    L"ProductID",
+    L"SystemManufacturer",
+    L"AcpiData",
+    L"SMBiosData",
+    L"SystemProductName",
+    L"DeviceDesc",
+    L"FriendlyName",
+    L"DisplayName",
+    L"ProviderName",
+    L"Device Description",
+
+};
+
+/**
+ * @brief A list of Registry keys speciffic indetifiable hypervisor vendors
+ * 
+ *
+ */
+static const PWCH HV_REGKEYS[] = {
+    L"VMware Tools",
+    L"qemu-ga",
+    L"SPICE Guest Tools",
+    L"VMware",
+    L"VMWARE",
+    L"VEN_15A",
+    L"VMware, Inc.",
+    L"INNOTEK GMBH",
+    L"VIRTUALBOX",
+    L"SUN MICROSYSTEMS",
+    L"VBOXVER",
+    L"VIRTUAL MACHINE",
+    L"GOOGLE COMPUTE ENGINE",
+    L"VBOXAPIC",
+};
 //////////////////////////////////////////////////
 //				   Functions					//
 //////////////////////////////////////////////////
@@ -430,6 +494,12 @@ TransparentHandleNtQueryAttributesFileSyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
 VOID
 TransparentHandleNtOpenDirectoryObjectSyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
+VOID
+TransparentHandleNtQueryInformationProcessSyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
+VOID
+TransparentHandleNtOpenFileSyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
 UINT32
 TransparentGetRand();

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -501,5 +501,11 @@ TransparentHandleNtQueryInformationProcessSyscall(VIRTUAL_MACHINE_STATE* VCpu);
 VOID
 TransparentHandleNtOpenFileSyscall(VIRTUAL_MACHINE_STATE* VCpu);
 
+VOID
+TransparentHandleNtOpenKeySyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
+VOID
+TransparentHandleNtQueryValueKeySyscall(VIRTUAL_MACHINE_STATE* VCpu);
+
 UINT32
 TransparentGetRand();

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -12,6 +12,12 @@
 #pragma once
 
 //////////////////////////////////////////////////
+//				     Globals 	    			//
+//////////////////////////////////////////////////
+
+static WORD TRANSPARENT_GENUINE_VENDOR_STRING_INDEX = 0;
+
+//////////////////////////////////////////////////
 //				      Locks 	    			//
 //////////////////////////////////////////////////
 
@@ -169,8 +175,6 @@ typedef struct _SYSTEM_PROCESS_INFORMATION {
 } SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
 
 static const PWCHAR TRANSPARENT_LEGIT_DEVICE_ID_VENDOR_STRINGS_WCHAR[] = {
-    L"",
-
     L"VEN_8086",  // Intel  
     L"VEN_10DE",  // NVIDIA  
     L"VEN_1002",  // AMD  
@@ -179,8 +183,6 @@ static const PWCHAR TRANSPARENT_LEGIT_DEVICE_ID_VENDOR_STRINGS_WCHAR[] = {
 };
 
 static const PWCHAR TRANSPARENT_LEGIT_VENDOR_STRINGS_WCHAR[] = {
-    L"",
-
     L"ASUS",
     L"ASUSTeK Computer INC.",
     L"ASUSTek",
@@ -345,97 +347,97 @@ static const PCHAR HV_DRIVER[] = {
  *
  */
 static const PWCH HV_FILES[] = {
-        //
-        // Hyperdbg Files
-        //
-        L"hyperhv",
-        L"hyperkd"
-        L"hyperlog",
-        L"libhyperdbg",
+    //
+    // Hyperdbg Files
+    //
+    L"hyperhv",
+    L"hyperkd"
+    L"hyperlog",
+    L"libhyperdbg",
 
 
 
-        //
-        // VMWare Files
-        //
-        L"vmmouse.sys",
-        L"Vmmouse.sys",
-        L"vmusbmouse.sys",
-        L"Vmusbmouse.sys",
-        L"vm3dgl.dll",
-        L"vmdum.dll",
-        L"VmGuestLibJava.dll",
-        L"vm3dver.dll",
-        L"vmtray.dll",
-        L"VMToolsHook.dll",
-        L"vmGuestLib.dll",
-        L"vmhgfs.dll",
-        L"vmhgfs.sys",
-        L"vm3dum64_loader.dll",
-        L"vm3dum64_10.dll",
-        L"vmnet.sys",
-        L"vmusb.sys",
-        L"vm3dmp.sys",
-        L"vmci.sys",
-        L"vmmemctl.sys",
-        L"vmx86.sys",
-        L"vmrawdsk.sys",
-        L"vmkdb.sys",
-        L"vmnetuserif.sys",
-        L"vmnetadapter.sys",
-        L"VMware Tools",
-        L"VMWare",
+    //
+    // VMWare Files
+    //
+    L"vmmouse.sys",
+    L"Vmmouse.sys",
+    L"vmusbmouse.sys",
+    L"Vmusbmouse.sys",
+    L"vm3dgl.dll",
+    L"vmdum.dll",
+    L"VmGuestLibJava.dll",
+    L"vm3dver.dll",
+    L"vmtray.dll",
+    L"VMToolsHook.dll",
+    L"vmGuestLib.dll",
+    L"vmhgfs.dll",
+    L"vmhgfs.sys",
+    L"vm3dum64_loader.dll",
+    L"vm3dum64_10.dll",
+    L"vmnet.sys",
+    L"vmusb.sys",
+    L"vm3dmp.sys",
+    L"vmci.sys",
+    L"vmmemctl.sys",
+    L"vmx86.sys",
+    L"vmrawdsk.sys",
+    L"vmkdb.sys",
+    L"vmnetuserif.sys",
+    L"vmnetadapter.sys",
+    L"VMware Tools",
+    L"VMWare",
 
 
-        //
-        // VirtualBox Files
-        //
-        L"VBoxMouse.sys",
-        L"VBoxGuest.sys",
-        L"VBoxSF.sys",
-        L"VBoxVideo.sys",
-        L"vboxoglpackspu.dll",
-        L"vboxoglpassthroughspu.dll",
-        L"vboxservice.exe",
-        L"vboxoglcrutil.dll",
-        L"vboxdisp.dll",
-        L"vboxhook.dll",
-        L"vboxmrxnp.dll",
-        L"vboxogl.dll",
-        L"vboxtray.exe",
-        L"VBoxControl.exe",
-        L"vboxoglerrorspu.dll",
-        L"vboxoglfeedbackspu.dll",
-        L"vboxoglarrayspu.dll",
-        L"vboxmrxnp.dll",
-        L"virtualbox guest additions",
+    //
+    // VirtualBox Files
+    //
+    L"VBoxMouse.sys",
+    L"VBoxGuest.sys",
+    L"VBoxSF.sys",
+    L"VBoxVideo.sys",
+    L"vboxoglpackspu.dll",
+    L"vboxoglpassthroughspu.dll",
+    L"vboxservice.exe",
+    L"vboxoglcrutil.dll",
+    L"vboxdisp.dll",
+    L"vboxhook.dll",
+    L"vboxmrxnp.dll",
+    L"vboxogl.dll",
+    L"vboxtray.exe",
+    L"VBoxControl.exe",
+    L"vboxoglerrorspu.dll",
+    L"vboxoglfeedbackspu.dll",
+    L"vboxoglarrayspu.dll",
+    L"vboxmrxnp.dll",
+    L"virtualbox guest additions",
 
-        //
-        // KVM files
-        //
-        L"balloon.sys",
-        L"netkvm.sys",
-        L"pvpanic.sys",
-        L"viofs.sys",
-        L"viogpudo.sys",
-        L"vioinput.sys",
-        L"viorng.sys",
-        L"vioscsi.sys",
-        L"vioser.sys",
-        L"viostor.sys",
+    //
+    // KVM files
+    //
+    L"balloon.sys",
+    L"netkvm.sys",
+    L"pvpanic.sys",
+    L"viofs.sys",
+    L"viogpudo.sys",
+    L"vioinput.sys",
+    L"viorng.sys",
+    L"vioscsi.sys",
+    L"vioser.sys",
+    L"viostor.sys",
 
-        //
-        // VPC files
-        //
-        L"vmsrvc.sys",
-        L"vmusrvc.sys",
-        L"vmsrvc.exe",
-        L"vmusrvc.exe",
-        L"vpc-s3.sys",
-        L"Virtio-Win",
-        
-        L"qemu-ga",
-        L"SPICE Guest Tools",
+    //
+    // VPC files
+    //
+    L"vmsrvc.sys",
+    L"vmusrvc.sys",
+    L"vmsrvc.exe",
+    L"vmusrvc.exe",
+    L"vpc-s3.sys",
+    L"Virtio-Win",
+    
+    L"qemu-ga",
+    L"SPICE Guest Tools",
 };
 
 /**
@@ -470,6 +472,7 @@ static const PWCH HV_REGKEYS[] = {
     L"vmusbmouse",
     L"VMware",
     L"VMWARE",
+    L"VMWare",
     L"vmdebug",
     L"vmmouse",
     L"VMTools",
@@ -566,8 +569,12 @@ static const PWCH TRANSPARENT_DETECTABLE_REGISTRY_KEYS[] = {
  *
  */
 static const PCHAR HV_FIRM_NAMES[] = {
+    "440BX Desktop Reference Platform",
+    "VMWARE, INC.",
+    "VMware, Inc.",
     "VMWARE",
     "VMware",
+    "VMW",
     "VS2005R2",
     "VirtualBox",
     "VIRTUALBOX",
@@ -575,6 +582,8 @@ static const PCHAR HV_FIRM_NAMES[] = {
     "ORACLE",
     "Innotek",
     "INNOTEK",
+    "Virtual",
+
 };
 //////////////////////////////////////////////////
 //				   Functions					//

--- a/hyperdbg/hyperhv/header/transparency/Transparency.h
+++ b/hyperdbg/hyperhv/header/transparency/Transparency.h
@@ -152,3 +152,6 @@ TransparentCallbackHandleAfterSyscall(VIRTUAL_MACHINE_STATE *           VCpu,
                                       UINT32                            ThreadId,
                                       UINT64                            Context,
                                       TRANSPARENT_MODE_CONTEXT_PARAMS * Params);
+
+VOID
+TransparentHandleSystemCallHook(VIRTUAL_MACHINE_STATE* VCpu);


### PR DESCRIPTION
# Description

Added interception of Windows system calls when the Transparency mode is enabled. Implemented handlers for multiple system calls that reveal hypervisor presence. Dynamic system call value loading is not implemented, so only Windows11 24H2 is verified to work reliably, code includes the system call numbers for 22H2 as well (as a comment).

## Type of change
- [ ] New feature (non-breaking change which adds functionality)