### PR TITLE
Temporarily work around Visual Studio 17.14.8 compiler optimization bug

### DIFF
--- a/examples/kernel/hyperdbg_driver/hyperdbg_driver.vcxproj
+++ b/examples/kernel/hyperdbg_driver/hyperdbg_driver.vcxproj
@@ -86,6 +86,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/examples/user/hyperdbg_app/hyperdbg_app.vcxproj
+++ b/examples/user/hyperdbg_app/hyperdbg_app.vcxproj
@@ -91,6 +91,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(ProjectDir)header;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/hyperdbg/hyperdbg-cli/hyperdbg-cli.vcxproj
+++ b/hyperdbg/hyperdbg-cli/hyperdbg-cli.vcxproj
@@ -110,6 +110,7 @@ copy "$(SolutionDir)miscellaneous\constants\pciid\pci.ids" "$(OutDir)constants\p
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/hyperdbg/hyperdbg-test/hyperdbg-test.vcxproj
+++ b/hyperdbg/hyperdbg-test/hyperdbg-test.vcxproj
@@ -91,6 +91,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/hyperdbg/hyperdbg.sln
+++ b/hyperdbg/hyperdbg.sln
@@ -279,7 +279,6 @@ Global
 		{B226530A-14B1-40AC-B82E-D9057400E7EE}.debug|x64.Build.0 = debug|x64
 		{B226530A-14B1-40AC-B82E-D9057400E7EE}.release|x64.ActiveCfg = release|x64
 		{B226530A-14B1-40AC-B82E-D9057400E7EE}.release|x64.Build.0 = release|x64
-		{B226530A-14B1-40AC-B82E-D9057400E7EE}.release|x64.Deploy.0 = release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/hyperdbg/hyperevade/hyperevade.vcxproj
+++ b/hyperdbg/hyperevade/hyperevade.vcxproj
@@ -87,6 +87,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/hyperdbg/hyperkd/hyperkd.vcxproj
+++ b/hyperdbg/hyperkd/hyperkd.vcxproj
@@ -91,6 +91,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/hyperdbg/hyperlog/hyperlog.vcxproj
+++ b/hyperdbg/hyperlog/hyperlog.vcxproj
@@ -87,6 +87,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/hyperdbg/kdserial/kdserial.vcxproj
+++ b/hyperdbg/kdserial/kdserial.vcxproj
@@ -118,6 +118,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories);$(KM_IncludePath);$(ProjectDir)..\..\inc</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(DDK_LIB_PATH);%(AdditionalLibraryDirectories);$(SolutionDir)libraries\kdserial\$(PlatformTarget)</AdditionalLibraryDirectories>

--- a/hyperdbg/libhyperdbg/libhyperdbg.vcxproj
+++ b/hyperdbg/libhyperdbg/libhyperdbg.vcxproj
@@ -106,6 +106,7 @@
       <CompileAs>CompileAsCpp</CompileAs>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/hyperdbg/script-engine/script-engine.vcxproj
+++ b/hyperdbg/script-engine/script-engine.vcxproj
@@ -93,6 +93,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)\script-engine\header;$(SolutionDir)\include;$(SolutionDir)\script-engine;$(SolutionDir)\script-eval;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/hyperdbg/symbol-parser/symbol-parser.vcxproj
+++ b/hyperdbg/symbol-parser/symbol-parser.vcxproj
@@ -87,6 +87,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)\include;$(SolutionDir)dependencies;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
# Description

This PR introduces a temporary workaround for a Visual Studio 17.14.8 compiler optimization bug.