### PR TITLE
v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0.0] - 2025-XX-XX
+New release of the HyperDbg Debugger.
+
+### Added
+
+### Changed
+- Restored the previous optimization on the release builds
+- Fixed the issue of not properly restoring registers after the 'CPUID' instruction
+
 ## [0.14.0.0] - 2025-07-23
 New release of the HyperDbg Debugger.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.0.0] - 2025-XX-XX
+## [0.14.1.0] - 2025-07-27
 New release of the HyperDbg Debugger.
-
-### Added
 
 ### Changed
 - Restored the previous optimization on the release builds
 - Fixed the issue of not properly restoring registers after the 'CPUID' instruction
+- Fixed the of the user debugger with the 'bp' and the '.start' commands
 
 ## [0.14.0.0] - 2025-07-23
 New release of the HyperDbg Debugger.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -4,7 +4,7 @@ The list provided comprises individuals who have made significant contributions 
 
 ## Credits:
 
-The attributions listed on this credits page are acknowledged without any particular order.
+Just so you know – the attributions listed on this credits page are acknowledged without any particular order.
 
 - All of the [contributors](https://github.com/HyperDbg/HyperDbg/graphs/contributors)
 - Sina Karvandi ([@Intel80x86](https://twitter.com/Intel80x86))
@@ -24,4 +24,5 @@ The attributions listed on this credits page are acknowledged without any partic
 - xmaple555 ([@xmaple555](https://github.com/xmaple555)) for contributions in HyperDbg core and the script engine
 - Abbas Masoumi Gorji ([@AbbasMasoumiG](https://twitter.com/AbbasMasoumiG))
 - Björn Ruytenberg ([@0Xiphorus](https://twitter.com/0Xiphorus))
-- Marcis Zarins ([@CokeTree3](https://github.com/CokeTree3))
+- Marcis Zarins ([@CokeTree3](https://github.com/CokeTree3)) for his works on enhancing HyperEvade project
+- Artem Shishkin ([@honorary_bot](https://twitter.com/honorary_bot)) for always answering our hypervisor questions

--- a/examples/kernel/hyperdbg_driver/hyperdbg_driver.vcxproj
+++ b/examples/kernel/hyperdbg_driver/hyperdbg_driver.vcxproj
@@ -86,7 +86,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <Optimization>Disabled</Optimization>
+      <Optimization>Full</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/examples/user/hyperdbg_app/hyperdbg_app.vcxproj
+++ b/examples/user/hyperdbg_app/hyperdbg_app.vcxproj
@@ -91,7 +91,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(ProjectDir)header;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/hyperdbg/hyperdbg-cli/hyperdbg-cli.vcxproj
+++ b/hyperdbg/hyperdbg-cli/hyperdbg-cli.vcxproj
@@ -110,7 +110,7 @@ copy "$(SolutionDir)miscellaneous\constants\pciid\pci.ids" "$(OutDir)constants\p
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/hyperdbg/hyperdbg-test/hyperdbg-test.vcxproj
+++ b/hyperdbg/hyperdbg-test/hyperdbg-test.vcxproj
@@ -91,7 +91,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/hyperdbg/hyperevade/hyperevade.vcxproj
+++ b/hyperdbg/hyperevade/hyperevade.vcxproj
@@ -87,7 +87,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>Full</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/hyperdbg/hyperkd/hyperkd.vcxproj
+++ b/hyperdbg/hyperkd/hyperkd.vcxproj
@@ -91,7 +91,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>Full</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/hyperdbg/hyperlog/hyperlog.vcxproj
+++ b/hyperdbg/hyperlog/hyperlog.vcxproj
@@ -87,7 +87,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>Full</Optimization>
     </ClCompile>
     <Link>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>

--- a/hyperdbg/include/SDK/headers/Constants.h
+++ b/hyperdbg/include/SDK/headers/Constants.h
@@ -17,8 +17,8 @@
 //////////////////////////////////////////////////
 
 #define VERSION_MAJOR 0
-#define VERSION_MINOR 15
-#define VERSION_PATCH 0
+#define VERSION_MINOR 14
+#define VERSION_PATCH 1
 
 //
 // Example of __DATE__ string: "Jul 27 2012"

--- a/hyperdbg/include/SDK/headers/Constants.h
+++ b/hyperdbg/include/SDK/headers/Constants.h
@@ -17,7 +17,7 @@
 //////////////////////////////////////////////////
 
 #define VERSION_MAJOR 0
-#define VERSION_MINOR 14
+#define VERSION_MINOR 15
 #define VERSION_PATCH 0
 
 //

--- a/hyperdbg/kdserial/kdserial.vcxproj
+++ b/hyperdbg/kdserial/kdserial.vcxproj
@@ -118,7 +118,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories);$(KM_IncludePath);$(ProjectDir)..\..\inc</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>Full</Optimization>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(DDK_LIB_PATH);%(AdditionalLibraryDirectories);$(SolutionDir)libraries\kdserial\$(PlatformTarget)</AdditionalLibraryDirectories>

--- a/hyperdbg/libhyperdbg/code/assembly/asm-vmx-checks.asm
+++ b/hyperdbg/libhyperdbg/code/assembly/asm-vmx-checks.asm
@@ -10,25 +10,32 @@ PUBLIC AsmVmxSupportDetection
 ;------------------------------------------------------------------------
 
 AsmVmxSupportDetection PROC
-
-    xor eax, eax
-    inc    eax
+    push    rbx
+    push    rcx
+    push    rdx
+    
+    xor     eax, eax
+    inc     eax
     cpuid
-    xor rax, rax
-    bt     ecx, 05h
-    jc     VMXSupport
+    xor     rax, rax
+    bt      ecx, 05h
+    jc      VMXSupport
     
 VMXNotSupport:
     jmp     RetInst
     
 VMXSupport:
-    mov    rax, 01h
+    mov     rax, 01h
     
 RetInst:
+    pop     rdx
+    pop     rcx
+    pop     rbx
+    
     ret
 
 AsmVmxSupportDetection ENDP
 
 ;------------------------------------------------------------------------
 
-END                     
+END

--- a/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/bp.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/bp.cpp
@@ -195,7 +195,7 @@ CommandBp(vector<CommandToken> CommandTokens, string Command)
 //
 #if ActivateUserModeDebugger == FALSE
 
-    if (!g_IsSerialConnectedToRemoteDebugger)
+    if (!g_IsSerialConnectedToRemoteDebuggee)
     {
         ShowMessages("the user-mode debugger in VMI Mode is still in the beta version and not stable. "
                      "we decided to exclude it from this release and release it in future versions. "

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/start.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/start.cpp
@@ -17,6 +17,7 @@
 extern std::wstring g_StartCommandPath;
 extern std::wstring g_StartCommandPathAndArguments;
 extern BOOLEAN      g_IsSerialConnectedToRemoteDebugger;
+extern BOOLEAN      g_IsSerialConnectedToRemoteDebuggee;
 
 /**
  * @brief help of the .start command
@@ -65,7 +66,7 @@ CommandStart(vector<CommandToken> CommandTokens, string Command)
 //
 #if ActivateUserModeDebugger == FALSE
 
-    if (!g_IsSerialConnectedToRemoteDebugger)
+    if (!g_IsSerialConnectedToRemoteDebuggee)
     {
         ShowMessages("the user-mode debugger in VMI Mode is still in the beta version and not stable. "
                      "we decided to exclude it from this release and release it in future versions. "

--- a/hyperdbg/libhyperdbg/libhyperdbg.vcxproj
+++ b/hyperdbg/libhyperdbg/libhyperdbg.vcxproj
@@ -106,7 +106,7 @@
       <CompileAs>CompileAsCpp</CompileAs>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/hyperdbg/script-engine/script-engine.vcxproj
+++ b/hyperdbg/script-engine/script-engine.vcxproj
@@ -93,7 +93,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)\script-engine\header;$(SolutionDir)\include;$(SolutionDir)\script-engine;$(SolutionDir)\script-eval;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/hyperdbg/symbol-parser/symbol-parser.vcxproj
+++ b/hyperdbg/symbol-parser/symbol-parser.vcxproj
@@ -87,7 +87,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)\include;$(SolutionDir)dependencies;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## [0.14.1.0] - 2025-07-27
New release of the HyperDbg Debugger.

### Changed
- Restored the previous optimization on the release builds
- Fixed the issue of not properly restoring registers after the 'CPUID' instruction
- Fixed the build issue with the user debugger with the 'bp' and the '.start' commands