### PR TITLE
Pe rich fix

### DIFF
--- a/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
@@ -320,8 +320,8 @@ PeHexDump(CHAR * Ptr, int Size, int SecAddress)
 BOOLEAN
 PeShowSectionInformationAndDump(const WCHAR * AddressOfFile, const CHAR * SectionToShow, BOOLEAN Is32Bit)
 {
-    PRICH_HEADER_INFO PeFileRichHeaderInfo{ 0 };
-    PRICH_HEADER PeFileRichHeader = {0};
+    RICH_HEADER_INFO PeFileRichHeaderInfo{ 0 };
+    RICH_HEADER PeFileRichHeader = {0};
     BOOLEAN                 Result = FALSE, RichFound = FALSE;
     HANDLE                  MapObjectHandle, FileHandle; // File Mapping Object
     UINT32                  NumberOfSections;            // Number of sections
@@ -389,10 +389,10 @@ PeShowSectionInformationAndDump(const WCHAR * AddressOfFile, const CHAR * Sectio
         memcpy(richHeaderPtr, DataPtr + IndexPointer, RichHeaderSize);
         delete[] DataPtr;
 
-        FindRichEntries(richHeaderPtr, RichHeaderSize, Key,PeFileRichHeaderInfo);
-        PeFileRichHeader->Entries = new RICH_HEADER_ENTRY[PeFileRichHeaderInfo->Entries];
+        FindRichEntries(richHeaderPtr, RichHeaderSize, Key,&PeFileRichHeaderInfo);
+        PeFileRichHeader.Entries = new RICH_HEADER_ENTRY[PeFileRichHeaderInfo.Entries];
 
-        SetRichEntries(RichHeaderSize, richHeaderPtr,PeFileRichHeader);
+        SetRichEntries(RichHeaderSize, richHeaderPtr,&PeFileRichHeader);
         RichFound = TRUE;
     }
 
@@ -450,16 +450,16 @@ PeShowSectionInformationAndDump(const WCHAR * AddressOfFile, const CHAR * Sectio
         ShowMessages("\n===============================================================================\n");
         ShowMessages("                              RICH HEADER                                     \n");
         ShowMessages("===============================================================================\n");
-        ShowMessages("Entries: %d\n\n", PeFileRichHeaderInfo->Entries);
+        ShowMessages("Entries: %d\n\n", PeFileRichHeaderInfo.Entries);
         ShowMessages("%-10s %-10s %-10s\n", "Build ID", "Prod ID", "Use Count");
         ShowMessages("---------------------------------------\n");
 
-        for (int i = 0; i < PeFileRichHeaderInfo->Entries; i++)
+        for (int i = 0; i < PeFileRichHeaderInfo.Entries; i++)
         {
             ShowMessages("0x%08X 0x%08X %10d\n",
-                         PeFileRichHeader->Entries[i].BuildID,
-                         PeFileRichHeader->Entries[i].ProdID,
-                         PeFileRichHeader->Entries[i].UseCount);
+                         PeFileRichHeader.Entries[i].BuildID,
+                         PeFileRichHeader.Entries[i].ProdID,
+                         PeFileRichHeader.Entries[i].UseCount);
         }
 
         ShowMessages("==============Rich Header End ==================\n");

--- a/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
@@ -11,23 +11,7 @@
  */
 #include "pch.h"
 
-/**
- * @brief Global structure containing Rich header metadata and buffer information
- *
- * Contains the size of the Rich header, pointer to the decrypted buffer,
- * and the number of tool entries found in the header.
- */
-//RICH_HEADER_INFO PeFileRichHeaderInfo = {0};
-
-/**
- * @brief Global structure containing the parsed Rich header entries
- *
- * Holds an array of individual Rich header entries, each containing
- * product ID, build ID, and usage count for compilation tools.
- */
-//RICH_HEADER PeFileRichHeader = {0};
-
-/**
+ /**
  * @brief Locates the Rich header signature in a PE file
  *
  * The Rich header is an undocumented Microsoft structure embedded in PE files
@@ -321,7 +305,7 @@ BOOLEAN
 PeShowSectionInformationAndDump(const WCHAR * AddressOfFile, const CHAR * SectionToShow, BOOLEAN Is32Bit)
 {
     RICH_HEADER_INFO PeFileRichHeaderInfo{ 0 };
-    RICH_HEADER PeFileRichHeader = {0};
+    RICH_HEADER PeFileRichHeader {0};
     BOOLEAN                 Result = FALSE, RichFound = FALSE;
     HANDLE                  MapObjectHandle, FileHandle; // File Mapping Object
     UINT32                  NumberOfSections;            // Number of sections

--- a/hyperdbg/libhyperdbg/header/pe-parser.h
+++ b/hyperdbg/libhyperdbg/header/pe-parser.h
@@ -51,10 +51,10 @@ INT
 FindRichHeader(PIMAGE_DOS_HEADER DosHeader, CHAR Key[]);
 
 VOID
-SetRichEntries(INT RichHeaderSize, CHAR * RichHeaderPtr);
+SetRichEntries(INT RichHeaderSize, CHAR * RichHeaderPtr,RICH_HEADER_ENTRY * PeFileRichHeader);
 
 VOID
-FindRichEntries(CHAR * RichHeaderPtr, INT RichHeaderSize, CHAR Key[]);
+FindRichEntries(CHAR * RichHeaderPtr, INT RichHeaderSize, CHAR Key[],RICH_HEADER_INFO * RichHeaderInfo);
 
 INT
 DecryptRichHeader(CHAR Key[], INT Index, CHAR * DataPtr);


### PR DESCRIPTION
# Description

In the PE parser’s Rich Header parsing logic, replaced the use of a global variable for storing RICH_HEADER_INFO,RICH_HEADER with a pointer-based approach.



## Type of change

Please delete options that are not relevant, or add anything you think would be helpful.

- [x] Refactor (code improvement without functional change)

