### PR TITLE
v0.15 (release 2)

### DIFF
--- a/hyperdbg/hyperevade/code/SyscallFootprints.c
+++ b/hyperdbg/hyperevade/code/SyscallFootprints.c
@@ -11,6 +11,28 @@
  */
 #include "pch.h"
 
+VOID
+TransparentHandleSystemCallHook(GUEST_REGS * Regs)
+{
+    UNREFERENCED_PARAMETER(Regs);
+}
+
+VOID
+TransparentCallbackHandleAfterSyscall(GUEST_REGS *                      Regs,
+                                      UINT32                            ProcessId,
+                                      UINT32                            ThreadId,
+                                      UINT64                            Context,
+                                      SYSCALL_CALLBACK_CONTEXT_PARAMS * Params)
+{
+    UNREFERENCED_PARAMETER(Regs);
+    UNREFERENCED_PARAMETER(ProcessId);
+    UNREFERENCED_PARAMETER(ThreadId);
+    UNREFERENCED_PARAMETER(Context);
+    UNREFERENCED_PARAMETER(Params);
+}
+
+#if DISABLE_HYPERDBG_HYPEREVADE == FALSE
+
 /**
  * @brief Handle The triggered hook on KiSystemCall64 system call handler
  * when the Transparency mode is enabled
@@ -1927,3 +1949,4 @@ TransparentCallbackHandleAfterSyscall(GUEST_REGS *                      Regs,
                 Params->OptionalParam4);
     }
 }
+#endif

--- a/hyperdbg/hyperevade/code/Transparency.c
+++ b/hyperdbg/hyperevade/code/Transparency.c
@@ -54,12 +54,13 @@ TransparentHideDebugger(HYPEREVADE_CALLBACKS *                        Hyperevade
         RtlCopyBytes(&g_SystemCallNumbersInformation,
                      &TransparentModeRequest->SystemCallNumbersInformation,
                      sizeof(SYSTEM_CALL_NUMBERS_INFORMATION));
-
+#if DISABLE_HYPERDBG_HYPEREVADE == FALSE
         //
         // Choose a random genuine vendor string to replace hypervisor vendor data
         //
         TRANSPARENT_GENUINE_VENDOR_STRING_INDEX = TransparentGetRand() %
                                                   (sizeof(TRANSPARENT_LEGIT_VENDOR_STRINGS_WCHAR) / sizeof(TRANSPARENT_LEGIT_VENDOR_STRINGS_WCHAR[0]));
+#endif
 
         //
         // Enable the transparent mode

--- a/hyperdbg/hyperevade/header/SyscallFootprints.h
+++ b/hyperdbg/hyperevade/header/SyscallFootprints.h
@@ -161,6 +161,8 @@ SYSTEM_CALL_NUMBERS_INFORMATION g_SystemCallNumbersInformation;
 //				   Constants        			//
 //////////////////////////////////////////////////
 
+#if DISABLE_HYPERDBG_HYPEREVADE == FALSE
+
 /**
  * @brief A list of windows processes, for which to ignore systemcall requests
  * when the transparency mode is enabled
@@ -608,6 +610,8 @@ static const PCHAR HV_FIRM_NAMES[] = {
     "Virtual",
 
 };
+
+#endif
 
 //////////////////////////////////////////////////
 //				   Functions					//

--- a/hyperdbg/hyperevade/header/pch.h
+++ b/hyperdbg/hyperevade/header/pch.h
@@ -24,6 +24,13 @@
 #ifdef ENV_WINDOWS
 
 //
+// The DLL is flagged by antivirus software, since it contains anti-debugging and anti-hypervisor methods
+// as well as different anti-debugging strings
+// For now, we disable the HyperDbg Hyperevade module
+//
+#    define DISABLE_HYPERDBG_HYPEREVADE TRUE
+
+//
 // Windows defined functions
 //
 #    include <ntddk.h>


### PR DESCRIPTION
## [0.15.0.0] - 2025-08-18
New release of the HyperDbg Debugger.

### Added
- Added the '!smi' command for performing operations related to System Management Interrupt (SMI) ([link](https://docs.hyperdbg.org/commands/extension-commands/smi))
- Export the SDK functions for SMI operations ([link](https://docs.hyperdbg.org/commands/extension-commands/smi#sdk))
- Check for Intel CET IBT (indirect branch tracking) support
- Check for Intel CET shadow stack support
- Added support to Intel CET for SYSCALL/SYSRET emulation ([link](https://docs.hyperdbg.org/commands/extension-commands/syscall))([link](https://docs.hyperdbg.org/commands/extension-commands/sysret))

### Changed
- The 'hyperhv' project now has build optimizations enabled
- Reformat VMXOFF restoring routines to restore general-purpose and XMM registers correctly before moving to the previous stack
- Fix unloading (VMXOFF) crash when restoring XMM registers
- Fix the problem with restoring XMM registers (#468) ([link](https://github.com/HyperDbg/HyperDbg/issues/468))
- Enhanced the '.pe' command to support PE Rich Headers thanks to [@Alish14](https://github.com/Alish14) ([link](https://github.com/HyperDbg/HyperDbg/pull/539))
- Updated ia32-doc to fix VMCS PL3 SSP fields ([link](https://github.com/HyperDbg/ia32-doc))
- Fix the terminating process issue of the '!syscall/!sysret' commands on 11 generation (Rocket Lake/Tiger Lake) and newer Intel processors ([link](https://github.com/HyperDbg/HyperDbg/issues/392))
- Reenable the support for the '.start' command in the Debugger mode ([link](https://docs.hyperdbg.org/commands/meta-commands/.start))
- The '!mode' event command is now compatible with different EPT hook commands (e.g., !epthook, !epthook2, !monitor, .start, and .restart) ([link](https://docs.hyperdbg.org/commands/extension-commands/mode))
- The '!mode' command doesn't need allocating extra EPTPs ([link](https://docs.hyperdbg.org/commands/extension-commands/mode))