### PR TITLE
Fix: An infinite vm-exit bug for !monitor x command

### DIFF
--- a/hyperdbg/hyperhv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hyperhv/code/vmm/ept/Ept.c
@@ -1085,15 +1085,15 @@ EptHandleEptViolation(VIRTUAL_MACHINE_STATE * VCpu)
     //
     __vmx_vmread(VMCS_GUEST_PHYSICAL_ADDRESS, &GuestPhysicalAddr);
 
-    if (ExecTrapHandleEptViolationVmexit(VCpu, &ViolationQualification))
-    {
-        return TRUE;
-    }
-    else if (EptHandlePageHookExit(VCpu, ViolationQualification, GuestPhysicalAddr))
+    if (EptHandlePageHookExit(VCpu, ViolationQualification, GuestPhysicalAddr))
     {
         //
         // Handled by page hook code
         //
+        return TRUE;
+    }
+    else if (ExecTrapHandleEptViolationVmexit(VCpu, &ViolationQualification))
+    {
         return TRUE;
     }
     else if (VmmCallbackUnhandledEptViolation(VCpu->CoreId, (UINT64)ViolationQualification.AsUInt, GuestPhysicalAddr))


### PR DESCRIPTION
An infinite vm-exit bug for !monitor x command

# Description

I found that there is an inifinite vm-exit bug after v0.14 patch and fixed it. 

When executing !monitor x command for user-mode process, I experienced system freezing. After debugging, I confirmed that the MBEC-related function always executed before checking monitor x, and even though the !mode command was not executed, it performed the same action as executing !mode user-mode process. The following is log.

0: kHyperDbg> .start path C:\\Users\\hhh\\Desktop\\Msgbox.exe
debuggee is running...
the target module is loaded and a breakpoint is set to the entrypoint
press 'g' to reach to the entrypoint of the main module...
00007ffe`9f309a90    75 21                               jnz 0x00007FFE9F309AB3 [not taken]

0: kHyperDbg> .process
process id: 1aa4
process (_EPROCESS): ffff9908`9a48a0c0
process name (16-Byte): Msgbox.exe

0: kHyperDbg> !monitor x 140001000 140001fff pid 1aa4

0: kHyperDbg> g
debuggee is running...
(07:05:52.958 - core : 0 - vmx-root? yes)        [+] Information (ExecTrapHandleEptViolationVmexit:671) | Reached to the user-mode of the process (0x1aa4) is executed address: 140001340
(07:05:52.958 - core : 0 - vmx-root? yes)        [+] Information (ExecTrapHandleEptViolationVmexit:671) | Reached to the user-mode of the process (0x1aa4) is executed address: fffff8072fc18d28
(07:05:52.958 - core : 0 - vmx-root? yes)        [+] Information (ExecTrapHandleEptViolationVmexit:671) | Reached to the user-mode of the process (0x1aa4) is executed address: fffff8072fc18d28
(07:05:52.958 - core : 0 - vmx-root? yes)        [+] Information (ExecTrapHandleEptViolationVmexit:671) | Reached to the user-mode of the process (0x1aa4) is executed address: fffff8072fc18d28
(07:05:52.958 - core : 0 - vmx-root? yes)        [+] Information (ExecTrapHandleEptViolationVmexit:671) | Reached to the user-mode of the process (0x1aa4) is executed address: fffff8072fc18d28
.....

The bug originates from the following code which is in the EptHandleEptViolation at Ept.c.
ExecTrapHandleEptViolationVmexit function (!mode command) always executes before EptHandlePageHookExit (!monitor x command). 

    if (ExecTrapHandleEptViolationVmexit(VCpu, &ViolationQualification))
    {
        return TRUE;
    }
    else if (EptHandlePageHookExit(VCpu, ViolationQualification, GuestPhysicalAddr))
    {
        //
        // Handled by page hook code
        //
        return TRUE;
    }

When the real monitor x events triggered, the ExecTrapHandleEptViolationVmexit func is executed and inside of it, if (!ViolationQualification->EptExecutableForUserMode && ViolationQualification->ExecuteAccess) becomes always true. As a result, it suppress rip it generates infinite vm-exit.

I also found that v0.13.2 does not generate infinite vm-exits !monitor x even it has a same function code of ExecTrapHandleEptViolationVmexit and EptHandleEptViolation function. I found the reason at the one of v0.14 commit (https://github.com/HyperDbg/HyperDbg/commit/8aa8289236a69447126840ab91ee78406553dc2e). It makes g_ExecTrapInitialized variable true (v0.13.2 does not) so that the condition "if (!g_ExecTrapInitialized)" at  ExecTrapHandleEptViolationVmexit does not return false.

Fixes # (issue)

I think there are several ways to fix it. I selected easiest way to fix it. 
I just changed the order of the EptHandlePageHookExit and ExecTrapHandleEptViolationVmexit. So that EptHandlePageHookExit func is always executed before ExecTrapHandleEptViolationVmexit func. Since EptHandlePageHookExit func does not impact !mode execution, even !monitor events are activated, It does not have any conflicts (I also tested !mode execution after patch). 

if (EptHandlePageHookExit(VCpu, ViolationQualification, GuestPhysicalAddr))
{
    //
    // Handled by page hook code
    //
    return TRUE;
}
else if (ExecTrapHandleEptViolationVmexit(VCpu, &ViolationQualification))
{
    return TRUE;
}

## Type of change

- [O] Bug fix (non-breaking change which fixes an issue)
