### PR TITLE
Fix !hide HyperEvade activation guard

### DIFF
--- a/hyperdbg/hyperevade/code/SyscallFootprints.c
+++ b/hyperdbg/hyperevade/code/SyscallFootprints.c
@@ -11,6 +11,8 @@
  */
 #include "pch.h"
 
+#if ActivateHyperEvadeProject != TRUE
+
 /**
  * @brief Handle The triggered hook on KiSystemCall64 system call handler
  * when the Transparency mode is disabled
@@ -50,7 +52,7 @@ TransparentCallbackHandleAfterSyscall(GUEST_REGS *                      Regs,
     UNREFERENCED_PARAMETER(Params);
 }
 
-#if DISABLE_HYPERDBG_HYPEREVADE == FALSE
+#else  // ActivateHyperEvadeProject != TRUE
 
 /**
  * @brief Handle The triggered hook on KiSystemCall64 system call handler
@@ -1968,4 +1970,4 @@ TransparentCallbackHandleAfterSyscall(GUEST_REGS *                      Regs,
                 Params->OptionalParam4);
     }
 }
-#endif
+#endif // ActivateHyperEvadeProject != TRUE

--- a/hyperdbg/hyperevade/code/Transparency.c
+++ b/hyperdbg/hyperevade/code/Transparency.c
@@ -54,7 +54,7 @@ TransparentHideDebugger(HYPEREVADE_CALLBACKS *                        Hyperevade
         RtlCopyBytes(&g_SystemCallNumbersInformation,
                      &TransparentModeRequest->SystemCallNumbersInformation,
                      sizeof(SYSTEM_CALL_NUMBERS_INFORMATION));
-#if DISABLE_HYPERDBG_HYPEREVADE == FALSE
+#if ActivateHyperEvadeProject == TRUE
         //
         // Choose a random genuine vendor string to replace hypervisor vendor data
         //

--- a/hyperdbg/hyperevade/header/SyscallFootprints.h
+++ b/hyperdbg/hyperevade/header/SyscallFootprints.h
@@ -161,7 +161,7 @@ SYSTEM_CALL_NUMBERS_INFORMATION g_SystemCallNumbersInformation;
 //				   Constants        			//
 //////////////////////////////////////////////////
 
-#if DISABLE_HYPERDBG_HYPEREVADE == FALSE
+#if ActivateHyperEvadeProject == TRUE
 
 /**
  * @brief A list of windows processes, for which to ignore systemcall requests

--- a/hyperdbg/hyperevade/header/pch.h
+++ b/hyperdbg/hyperevade/header/pch.h
@@ -24,13 +24,6 @@
 #ifdef HYPERDBG_ENV_WINDOWS
 
 //
-// The DLL is flagged by antivirus software, since it contains anti-debugging and anti-hypervisor methods
-// as well as different anti-debugging strings
-// For now, we disable the HyperDbg Hyperevade module
-//
-#    define DISABLE_HYPERDBG_HYPEREVADE TRUE
-
-//
 // Windows defined functions
 //
 #    include <ntddk.h>

--- a/hyperdbg/include/config/Configuration.h
+++ b/hyperdbg/include/config/Configuration.h
@@ -77,4 +77,4 @@
 /**
  * @brief Activates the hyperevade project
  */
-#define ActivateHyperEvadeProject TRUE
+#define ActivateHyperEvadeProject FALSE

--- a/hyperdbg/libhyperdbg/code/debugger/commands/extension-commands/hide.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/extension-commands/hide.cpp
@@ -217,7 +217,7 @@ CommandHideFillSystemCalls(SYSTEM_CALL_NUMBERS_INFORMATION * SyscallNumberDetail
         Result = FALSE;
     }
 
-    return TRUE;
+    return Result;
 }
 
 /**
@@ -265,6 +265,12 @@ HyperDbgEnableTransparentMode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsPr
         //
         HideRequest.LengthOfProcessName = (UINT32)strlen(ProcessName) + 1;
         RequestBufferSize               = sizeof(DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE) + HideRequest.LengthOfProcessName;
+    }
+
+    if (!CommandHideFillSystemCalls(&HideRequest.SystemCallNumbersInformation))
+    {
+        ShowMessages("warning, failed to resolve one or more syscall numbers for transparent-mode\n");
+        return FALSE;
     }
 
     //
@@ -365,7 +371,7 @@ CommandHide(vector<CommandToken> CommandTokens, string Command)
     UINT32  TargetPid;
     BOOLEAN TrueIfProcessIdAndFalseIfProcessName;
 
-#if ActivateHyperEvadeProject == TRUE
+#if ActivateHyperEvadeProject != TRUE
 
     ShowMessages("warning, the !hide command (hyperevade project) is in the Beta phase and is not yet well-tested, "
                  "so it is disabled in this version. If you want to test, you can enable it "


### PR DESCRIPTION
# Description

Fix `!hide` so the HyperEvade disabled warning is shown only when `ActivateHyperEvadeProject` is not `TRUE`.

Also aligns the HyperEvade compile gates with that config flag and avoids sending transparent-mode IOCTLs when required syscall numbers cannot be resolved.

Fixes #571 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Additional notes 
I did not change file versions/dates.
I Included the syscall check because fixing the `!hide` guard re-enables this path.