### PR TITLE
Fix synchronous debugger device IOCTL handles

### DIFF
--- a/hyperdbg/libhyperdbg/code/app/libhyperdbg.cpp
+++ b/hyperdbg/libhyperdbg/code/app/libhyperdbg.cpp
@@ -162,6 +162,7 @@ INT
 HyperDbgInitHyperTraceModule()
 {
     BOOL                            Status;
+    DWORD                           BytesReturned;
     DEBUGGER_INIT_HYPERTRACE_PACKET InitHyperTracePacket = {0};
 
     AssertShowMessageReturnStmt(g_DeviceHandle, ASSERT_MESSAGE_DRIVER_NOT_LOADED, AssertReturnOne);
@@ -175,7 +176,7 @@ HyperDbgInitHyperTraceModule()
                              SIZEOF_DEBUGGER_INIT_HYPERTRACE_PACKET, // Length of input buffer in bytes.
                              &InitHyperTracePacket,                  // Output Buffer from driver.
                              SIZEOF_DEBUGGER_INIT_HYPERTRACE_PACKET, // Length of output buffer in bytes.
-                             NULL,                                   // Bytes placed in buffer.
+                             &BytesReturned,                         // Bytes placed in buffer.
                              NULL                                    // synchronous call
     );
 
@@ -210,6 +211,7 @@ INT
 HyperDbgInitVmmModule()
 {
     BOOL                     Status;
+    DWORD                    BytesReturned;
     DEBUGGER_INIT_VMM_PACKET InitVmmPacket = {0};
 
     AssertShowMessageReturnStmt(g_DeviceHandle, ASSERT_MESSAGE_DRIVER_NOT_LOADED, AssertReturnOne);
@@ -228,7 +230,7 @@ HyperDbgInitVmmModule()
                              SIZEOF_DEBUGGER_INIT_VMM_PACKET, // Length of input buffer in bytes.
                              &InitVmmPacket,                  // Output Buffer from driver.
                              SIZEOF_DEBUGGER_INIT_VMM_PACKET, // Length of output buffer in bytes.
-                             NULL,                            // Bytes placed in buffer.
+                             &BytesReturned,                  // Bytes placed in buffer.
                              NULL                             // synchronous call
     );
 
@@ -305,7 +307,7 @@ HyperDbgCreateHandleFromKdModule()
         FILE_SHARE_READ | FILE_SHARE_WRITE,
         NULL, /// lpSecurityAttirbutes
         OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
+        FILE_ATTRIBUTE_NORMAL,
         NULL); /// lpTemplateFile
 
     if (g_DeviceHandle == INVALID_HANDLE_VALUE)
@@ -357,7 +359,8 @@ HyperDbgCreateHandleFromKdModule()
 INT
 HyperDbgUnloadVmm()
 {
-    BOOL Status;
+    BOOL  Status;
+    DWORD BytesReturned;
 
     AssertShowMessageReturnStmt(g_DeviceHandle, ASSERT_MESSAGE_DRIVER_NOT_LOADED, AssertReturnOne);
 
@@ -378,7 +381,7 @@ HyperDbgUnloadVmm()
                                                   // as the driver is x64 and has 64 bit values)
                              NULL,                // Output Buffer from driver.
                              0,                   // Length of output buffer in bytes.
-                             NULL,                // Bytes placed in buffer.
+                             &BytesReturned,      // Bytes placed in buffer.
                              NULL                 // synchronous call
     );
 
@@ -404,7 +407,7 @@ HyperDbgUnloadVmm()
                                                              // driver is x64 and has 64 bit values)
         NULL,                                                // Output Buffer from driver.
         0,                                                   // Length of output buffer in bytes.
-        NULL,                                                // Bytes placed in buffer.
+        &BytesReturned,                                      // Bytes placed in buffer.
         NULL                                                 // synchronous call
     );
 

--- a/hyperdbg/libhyperdbg/code/app/packets.cpp
+++ b/hyperdbg/libhyperdbg/code/app/packets.cpp
@@ -42,12 +42,9 @@ ReadIrpBasedBuffer()
     RegisterEvent.Type   = IRP_BASED;
 
     //
-    // Create another handle to be used in for reading kernel messages,
-    // it is because I noticed that if I use a same handle for IRP Pending
-    // and other IOCTLs then if I complete that IOCTL then both of the current
-    // IOCTL and the Pending IRP are completed and return to user mode,
-    // even if it's odd but that what happens, so this way we can solve it
-    // if you know why this problem happens, then contact me !
+    // Keep the packet reader on a dedicated synchronous handle. It blocks on
+    // a pending IOCTL while the main debugger handle continues sending other
+    // synchronous IOCTLs.
     //
     Handle = CreateFileA(
         "\\\\.\\HyperDbgDebuggerDevice",
@@ -55,7 +52,7 @@ ReadIrpBasedBuffer()
         FILE_SHARE_READ | FILE_SHARE_WRITE,
         NULL, /// lpSecurityAttirbutes
         OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
+        FILE_ATTRIBUTE_NORMAL,
         NULL); /// lpTemplateFile
 
     if (Handle == INVALID_HANDLE_VALUE)

--- a/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/e.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/e.cpp
@@ -69,6 +69,7 @@ WriteMemoryContent(UINT64                         AddressToEdit,
                    UINT64 *                       BufferToEdit)
 {
     BOOL                   Status;
+    DWORD                  BytesReturned;
     BOOLEAN                StatusReturn = FALSE;
     DEBUGGER_EDIT_MEMORY * FinalBuffer;
     DEBUGGER_EDIT_MEMORY   EditMemoryRequest = {0};
@@ -147,7 +148,7 @@ WriteMemoryContent(UINT64                         AddressToEdit,
             FinalSize,                   // Input buffer length
             FinalBuffer,                 // Output Buffer from driver.
             SIZEOF_DEBUGGER_EDIT_MEMORY, // Length of output buffer in bytes.
-            NULL,                        // Bytes placed in buffer.
+            &BytesReturned,              // Bytes placed in buffer.
             NULL                         // synchronous call
         );
 

--- a/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/s.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/debugging-commands/s.cpp
@@ -62,6 +62,7 @@ VOID
 CommandSearchSendRequest(UINT64 * BufferToSendAsIoctl, UINT32 BufferToSendAsIoctlSize)
 {
     BOOL    Status;
+    DWORD   BytesReturned;
     UINT64  CurrentValue;
     PUINT64 ResultsBuffer = NULL;
 
@@ -87,7 +88,7 @@ CommandSearchSendRequest(UINT64 * BufferToSendAsIoctl, UINT32 BufferToSendAsIoct
                         ResultsBuffer,                // Output Buffer from driver.
                         MaximumSearchResults *
                             sizeof(UINT64), // Length of output buffer in bytes.
-                        NULL,               // Bytes placed in buffer.
+                        &BytesReturned,     // Bytes placed in buffer.
                         NULL                // synchronous call
         );
 


### PR DESCRIPTION
# Description

Fix `libhyperdbg` debugger device handles so synchronous `DeviceIoControl` calls no longer use handles opened with `FILE_FLAG_OVERLAPPED`.

The packet reader still uses a dedicated handle for the pending IRP path, but that handle now matches the existing synchronous IOCTL usage. Also passes a real bytes-returned pointer for synchronous IOCTLs that previously used `NULL`.

Fixes #594 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
