### PR TITLE
Fix action cleanup list removal in debugger events

### DIFF
--- a/hyperdbg/hyperkd/code/debugger/core/Debugger.c
+++ b/hyperdbg/hyperkd/code/debugger/core/Debugger.c
@@ -2538,12 +2538,12 @@ DebuggerRemoveAllActionsFromEvent(PDEBUGGER_EVENT Event, BOOLEAN PoolManagerAllo
     //
     // Remove all actions
     //
-    TempList  = &Event->ActionsListHead;
-    TempList2 = TempList;
+    TempList  = Event->ActionsListHead.Flink;
+    TempList2 = &Event->ActionsListHead;
 
-    while (TempList2 != TempList->Flink)
+    while (TempList != TempList2)
     {
-        TempList                             = TempList->Flink;
+        PLIST_ENTRY            NextList      = TempList->Flink;
         PDEBUGGER_EVENT_ACTION CurrentAction = CONTAINING_RECORD(TempList, DEBUGGER_EVENT_ACTION, ActionsList);
 
         //
@@ -2570,6 +2570,8 @@ DebuggerRemoveAllActionsFromEvent(PDEBUGGER_EVENT Event, BOOLEAN PoolManagerAllo
         // if it's a custom buffer then the buffer
         // is appended to the Action
         //
+        RemoveEntryList(&CurrentAction->ActionsList);
+
         if (PoolManagerAllocatedMemory)
         {
             PoolManagerFreePool((UINT64)CurrentAction);
@@ -2578,6 +2580,8 @@ DebuggerRemoveAllActionsFromEvent(PDEBUGGER_EVENT Event, BOOLEAN PoolManagerAllo
         {
             PlatformMemFreePool(CurrentAction);
         }
+
+        TempList = NextList;
     }
     //
     // Remember to free the pool


### PR DESCRIPTION
# Description

Fix `DebuggerRemoveAllActionsFromEvent` so each action is removed from `ActionsListHead` before its backing allocation is freed.

`RemoveEntryList`:
> “removes the entry by setting the Flink member of the entry before Entry to point to the entry after Entry, and the Blink member of the entry after Entry to point to the entry before Entry.”

https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-removeentrylist

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
