### PR TITLE
Add transparent-mode evade mask selection

### DIFF
--- a/hyperdbg/hyperevade/code/Transparency.c
+++ b/hyperdbg/hyperevade/code/Transparency.c
@@ -1,6 +1,7 @@
 ﻿/**
  * @file Transparency.c
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief Try to hide the debugger from anti-debugging and anti-hypervisor methods
  * @details
  * @version 0.1
@@ -23,6 +24,19 @@ BOOLEAN
 TransparentHideDebugger(HYPEREVADE_CALLBACKS *                        HyperevadeCallbacks,
                         DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE * TransparentModeRequest)
 {
+    UINT32 EvadeMask = TransparentModeRequest->EvadeMask;
+
+    if (EvadeMask == 0)
+    {
+        EvadeMask = TRANSPARENT_EVADE_MASK_DEFAULT;
+    }
+
+    if ((EvadeMask & ~TRANSPARENT_EVADE_MASK_ALL) != 0)
+    {
+        TransparentModeRequest->KernelStatus = DEBUGGER_ERROR_UNABLE_TO_HIDE_OR_UNHIDE_DEBUGGER;
+        return FALSE;
+    }
+
     //
     // Check if any of the required callbacks are NULL
     //
@@ -66,6 +80,8 @@ TransparentHideDebugger(HYPEREVADE_CALLBACKS *                        Hyperevade
         // Enable the transparent mode
         //
         g_TransparentMode                    = TRUE;
+        g_TransparentEvadeMask               = EvadeMask;
+        TransparentModeRequest->EvadeMask    = EvadeMask;
         TransparentModeRequest->KernelStatus = DEBUGGER_OPERATION_WAS_SUCCESSFUL;
 
         //
@@ -93,7 +109,8 @@ TransparentUnhideDebugger()
         //
         // Disable the transparent-mode
         //
-        g_TransparentMode = FALSE;
+        g_TransparentMode      = FALSE;
+        g_TransparentEvadeMask = 0;
 
         return TRUE;
     }

--- a/hyperdbg/hyperevade/code/VmxFootprints.c
+++ b/hyperdbg/hyperevade/code/VmxFootprints.c
@@ -1,6 +1,7 @@
 /**
  * @file VmxFootprints.c
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief Try to hide VMX methods from anti-debugging and anti-hypervisor
  * @details
  * @version 0.14
@@ -22,6 +23,11 @@
 VOID
 TransparentCheckAndModifyCpuid(PGUEST_REGS Regs, INT32 CpuInfo[])
 {
+    if ((g_TransparentEvadeMask & TRANSPARENT_EVADE_MASK_CPUID) == 0)
+    {
+        return;
+    }
+
     if (Regs->rax == CPUID_PROCESSOR_AND_PROCESSOR_FEATURE_IDENTIFIERS)
     {
         //
@@ -50,6 +56,14 @@ TransparentCheckAndModifyCpuid(PGUEST_REGS Regs, INT32 CpuInfo[])
 BOOLEAN
 TransparentCheckAndModifyMsrRead(PGUEST_REGS Regs, UINT32 TargetMsr)
 {
+    if ((g_TransparentEvadeMask & TRANSPARENT_EVADE_MASK_MSR) == 0)
+    {
+        UNREFERENCED_PARAMETER(Regs);
+        UNREFERENCED_PARAMETER(TargetMsr);
+
+        return FALSE;
+    }
+
     //
     // The MSR range between 40000000H and 400000F0H is reserved and usually used by hypervisors
     // when the guest operating system is Windows to indicate the OS identifier
@@ -92,6 +106,14 @@ TransparentCheckAndModifyMsrRead(PGUEST_REGS Regs, UINT32 TargetMsr)
 BOOLEAN
 TransparentCheckAndModifyMsrWrite(PGUEST_REGS Regs, UINT32 TargetMsr)
 {
+    if ((g_TransparentEvadeMask & TRANSPARENT_EVADE_MASK_MSR) == 0)
+    {
+        UNREFERENCED_PARAMETER(Regs);
+        UNREFERENCED_PARAMETER(TargetMsr);
+
+        return FALSE;
+    }
+
     // if (TargetMsr >= RESERVED_MSR_RANGE_LOW && TargetMsr <= RESERVED_MSR_RANGE_HI)
     // {
     //     //
@@ -130,6 +152,11 @@ TransparentCheckAndModifyMsrWrite(PGUEST_REGS Regs, UINT32 TargetMsr)
 VOID
 TransparentCheckAndTrapFlagAfterVmexit()
 {
+    if ((g_TransparentEvadeMask & TRANSPARENT_EVADE_MASK_TRAP_FLAG) == 0)
+    {
+        return;
+    }
+
     //
     // If RIP is incremented, then we emulate an instruction, and then
     // we need to handle the trap flag if it is set in a guest

--- a/hyperdbg/hyperevade/header/Transparency.h
+++ b/hyperdbg/hyperevade/header/Transparency.h
@@ -1,6 +1,7 @@
 /**
  * @file Transparency.h
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief hide the debugger from anti-debugging and anti-hypervisor methods (headers)
  * @details
  * @version 0.1
@@ -63,6 +64,12 @@ typedef struct _TRANSPARENCY_PROCESS
  *
  */
 BOOLEAN g_TransparentMode;
+
+/**
+ * @brief The enabled transparent-mode feature mask
+ *
+ */
+UINT32 g_TransparentEvadeMask;
 
 //////////////////////////////////////////////////
 //				   Functions					//

--- a/hyperdbg/hyperhv/code/hooks/syscall-hook/SyscallCallback.c
+++ b/hyperdbg/hyperhv/code/hooks/syscall-hook/SyscallCallback.c
@@ -1,6 +1,7 @@
 ﻿/**
  * @file SyscallCallback.c
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief Implementation of the functions related to the callback for Syscall
  * @details
  *
@@ -76,6 +77,17 @@ SyscallCallbackInitialize()
 }
 
 /**
+ * @brief Check whether the syscall callback is initialized
+ *
+ * @return BOOLEAN
+ */
+BOOLEAN
+SyscallCallbackIsInitialized()
+{
+    return g_SyscallCallbackStatus;
+}
+
+/**
  * @brief Uninitialize the syscall callback
  *
  * @return BOOLEAN
@@ -86,9 +98,14 @@ SyscallCallbackUninitialize()
     if (g_SyscallCallbackStatus)
     {
         //
-        // Disable the syscall callback
+        // Unset the EPT hook from the syscall entry before disabling state.
         //
-        g_SyscallCallbackStatus = FALSE;
+        if (!ConfigureEptHookUnHookSingleAddress((UINT64)g_SystemCallHookAddress, (UINT64)NULL, (UINT32)(ULONG_PTR)PsGetCurrentProcessId()))
+        {
+            LogInfo("Error while removing the EPT hook from windows syscall handler at address 0x%p", g_SystemCallHookAddress);
+
+            return FALSE;
+        }
 
         //
         // Unset the trap flags #DBs and #BPs for the syscall callback
@@ -100,15 +117,9 @@ SyscallCallbackUninitialize()
         //
         PlatformMemFreePool(g_SyscallCallbackTrapFlagState);
 
-        MSR Msr   = {0};
-        Msr.Flags = CpuReadMsr(IA32_LSTAR);
-
-        if (!ConfigureEptHookUnHookSingleAddress((UINT64)(Msr.Flags + 3), (UINT64)NULL, (UINT32)(ULONG_PTR)PsGetCurrentProcessId()))
-        {
-            LogInfo("Error while removing the EPT hook from windows syscall handler at address 0x%p+3", Msr.Flags);
-
-            return FALSE;
-        }
+        g_SyscallCallbackTrapFlagState = NULL;
+        g_SystemCallHookAddress        = NULL;
+        g_SyscallCallbackStatus        = FALSE;
 
         return TRUE;
     }

--- a/hyperdbg/hyperhv/code/interface/HyperEvade.c
+++ b/hyperdbg/hyperhv/code/interface/HyperEvade.c
@@ -1,6 +1,7 @@
 /**
  * @file HyperEvade.c
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief Hyperevade function wrappers
  * @details
  *
@@ -24,6 +25,20 @@ BOOLEAN
 TransparentHideDebuggerWrapper(DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE * TransparentModeRequest)
 {
     HYPEREVADE_CALLBACKS HyperevadeCallbacks = {0};
+    UINT32               EvadeMask           = TransparentModeRequest->EvadeMask;
+
+    if (EvadeMask == 0)
+    {
+        EvadeMask = TRANSPARENT_EVADE_MASK_DEFAULT;
+    }
+
+    if ((EvadeMask & ~TRANSPARENT_EVADE_MASK_ALL) != 0)
+    {
+        TransparentModeRequest->KernelStatus = DEBUGGER_ERROR_UNABLE_TO_HIDE_OR_UNHIDE_DEBUGGER;
+        return FALSE;
+    }
+
+    TransparentModeRequest->EvadeMask = EvadeMask;
 
     //
     // *** Fill the callbacks ***
@@ -67,19 +82,23 @@ TransparentHideDebuggerWrapper(DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE * Tra
     HyperevadeCallbacks.EventInjectGeneralProtection = EventInjectGeneralProtection;
 
     //
-    // Initialize the syscall callback mechanism from hypervisor
-    //
-    if (!SyscallCallbackInitialize())
-    {
-        TransparentModeRequest->KernelStatus = DEBUGGER_ERROR_UNABLE_TO_HIDE_OR_UNHIDE_DEBUGGER;
-        return FALSE;
-    }
-
-    //
     // Call the hyperevade hide debugger function
     //
     if (TransparentHideDebugger(&HyperevadeCallbacks, TransparentModeRequest))
     {
+        //
+        // Initialize the syscall callback mechanism from hypervisor after
+        // transparent-mode accepts the request as the active state.
+        //
+        if ((EvadeMask & TRANSPARENT_EVADE_MASK_SYSCALL_HOOK) != 0 && !SyscallCallbackInitialize())
+        {
+            TransparentUnhideDebugger();
+
+            TransparentModeRequest->KernelStatus = DEBUGGER_ERROR_UNABLE_TO_HIDE_OR_UNHIDE_DEBUGGER;
+            g_CheckForFootprints                 = FALSE;
+            return FALSE;
+        }
+
         //
         // Status is set within the transparent mode (hyperevade) module
         //
@@ -105,10 +124,15 @@ TransparentHideDebuggerWrapper(DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE * Tra
 BOOLEAN
 TransparentUnhideDebuggerWrapper(DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE * TransparentModeRequest)
 {
-    //
-    // Uninitialize the syscall callback mechanism from hypervisor
-    //
-    SyscallCallbackUninitialize();
+    if (SyscallCallbackIsInitialized() && !SyscallCallbackUninitialize())
+    {
+        if (TransparentModeRequest != NULL)
+        {
+            TransparentModeRequest->KernelStatus = DEBUGGER_ERROR_UNABLE_TO_HIDE_OR_UNHIDE_DEBUGGER;
+        }
+
+        return FALSE;
+    }
 
     if (TransparentUnhideDebugger())
     {

--- a/hyperdbg/hyperhv/header/hooks/SyscallCallback.h
+++ b/hyperdbg/hyperhv/header/hooks/SyscallCallback.h
@@ -1,6 +1,7 @@
 /**
  * @file SyscallHook.h
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief Header for syscall hook callbacks
  * @details
  *
@@ -77,6 +78,9 @@ typedef struct _SYSCALL_CALLBACK_TRAP_FLAG_STATE
 
 BOOLEAN
 SyscallCallbackInitialize();
+
+BOOLEAN
+SyscallCallbackIsInitialized();
 
 BOOLEAN
 SyscallCallbackUninitialize();

--- a/hyperdbg/include/SDK/headers/Constants.h
+++ b/hyperdbg/include/SDK/headers/Constants.h
@@ -1,6 +1,7 @@
 /**
  * @file Constants.h
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief HyperDbg's SDK constants
  * @details This file contains definitions of constants
  * used in HyperDbg
@@ -667,6 +668,18 @@ typedef enum _SEGMENT_REGISTERS
  */
 #define CPUID_HV_VENDOR_AND_MAX_FUNCTIONS 0x40000000
 #define CPUID_HV_INTERFACE                0x40000001
+
+/**
+ * @brief Transparent-mode feature mask
+ *
+ */
+#define TRANSPARENT_EVADE_MASK_SYSCALL_HOOK 0x00000001
+#define TRANSPARENT_EVADE_MASK_CPUID        0x00000002
+#define TRANSPARENT_EVADE_MASK_MSR          0x00000004
+#define TRANSPARENT_EVADE_MASK_TRAP_FLAG    0x00000008
+#define TRANSPARENT_EVADE_MASK_ALL \
+    (TRANSPARENT_EVADE_MASK_SYSCALL_HOOK | TRANSPARENT_EVADE_MASK_CPUID | TRANSPARENT_EVADE_MASK_MSR | TRANSPARENT_EVADE_MASK_TRAP_FLAG)
+#define TRANSPARENT_EVADE_MASK_DEFAULT TRANSPARENT_EVADE_MASK_ALL
 
 /**
  * @brief Cpuid to get virtual address width

--- a/hyperdbg/include/SDK/headers/RequestStructures.h
+++ b/hyperdbg/include/SDK/headers/RequestStructures.h
@@ -1,6 +1,7 @@
 /**
  * @file RequestStructures.h
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief HyperDbg's SDK Headers Request Packets
  * @details This file contains definitions of request packets (enums, structs)
  * @version 0.2
@@ -612,6 +613,8 @@ typedef struct _DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE
     UINT32 KernelStatus; /* DEBUGGER_OPERATION_WAS_SUCCESSFUL ,
                           DEBUGGER_ERROR_UNABLE_TO_HIDE_OR_UNHIDE_DEBUGGER
                           */
+
+    UINT32 EvadeMask; // zero means TRANSPARENT_EVADE_MASK_DEFAULT
 
 } DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE,
     *PDEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE;

--- a/hyperdbg/include/SDK/imports/user/HyperDbgLibImports.h
+++ b/hyperdbg/include/SDK/imports/user/HyperDbgLibImports.h
@@ -1,6 +1,7 @@
 /**
  * @file HyperDbgLibImports.h
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief Headers relating exported functions from controller interface
  * @version 0.2
  * @date 2023-02-02
@@ -290,6 +291,9 @@ hyperdbg_u_lbr_dump(HYPERTRACE_LBR_DUMP_PACKETS * LbrdumpRequest);
 //
 IMPORT_EXPORT_LIBHYPERDBG BOOLEAN
 hyperdbg_u_enable_transparent_mode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId);
+
+IMPORT_EXPORT_LIBHYPERDBG BOOLEAN
+hyperdbg_u_enable_transparent_mode_ex(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId, UINT32 EvadeMask);
 
 IMPORT_EXPORT_LIBHYPERDBG BOOLEAN
 hyperdbg_u_disable_transparent_mode();

--- a/hyperdbg/libhyperdbg/code/debugger/commands/extension-commands/hide.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/extension-commands/hide.cpp
@@ -1,6 +1,7 @@
 /**
  * @file hide.cpp
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief !hide command
  * @details
  * @version 0.1
@@ -225,17 +226,19 @@ CommandHideFillSystemCalls(SYSTEM_CALL_NUMBERS_INFORMATION * SyscallNumberDetail
  * @param ProcessId
  * @param ProcessName
  * @param IsProcessId
+ * @param EvadeMask
  *
  * @return BOOLEAN
  */
 BOOLEAN
-HyperDbgEnableTransparentMode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId)
+HyperDbgEnableTransparentModeEx(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId, UINT32 EvadeMask)
 {
     BOOLEAN                                      Status;
     ULONG                                        ReturnedLength;
     DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE  HideRequest        = {0};
     PDEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE FinalRequestBuffer = 0;
     SIZE_T                                       RequestBufferSize  = 0;
+    UINT32                                       EffectiveEvadeMask = EvadeMask == 0 ? TRANSPARENT_EVADE_MASK_DEFAULT : EvadeMask;
 
     //
     // Check if debugger is loaded or not
@@ -245,7 +248,14 @@ HyperDbgEnableTransparentMode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsPr
     //
     // We wanna hide the debugger and make transparent vm-exits
     //
-    HideRequest.IsHide = TRUE;
+    if ((EffectiveEvadeMask & ~TRANSPARENT_EVADE_MASK_ALL) != 0)
+    {
+        ShowMessages("unknown transparent-mode evade mask bits\n");
+        return FALSE;
+    }
+
+    HideRequest.IsHide    = TRUE;
+    HideRequest.EvadeMask = EffectiveEvadeMask;
 
     HideRequest.TrueIfProcessIdAndFalseIfProcessName = IsProcessId;
 
@@ -267,7 +277,8 @@ HyperDbgEnableTransparentMode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsPr
         RequestBufferSize               = sizeof(DEBUGGER_HIDE_AND_TRANSPARENT_DEBUGGER_MODE) + HideRequest.LengthOfProcessName;
     }
 
-    if (!CommandHideFillSystemCalls(&HideRequest.SystemCallNumbersInformation))
+    if ((EffectiveEvadeMask & TRANSPARENT_EVADE_MASK_SYSCALL_HOOK) != 0 &&
+        !CommandHideFillSystemCalls(&HideRequest.SystemCallNumbersInformation))
     {
         ShowMessages("warning, failed to resolve one or more syscall numbers for transparent-mode\n");
         return FALSE;
@@ -359,6 +370,20 @@ HyperDbgEnableTransparentMode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsPr
 }
 
 /**
+ * @brief Enable transparent mode
+ * @param ProcessId
+ * @param ProcessName
+ * @param IsProcessId
+ *
+ * @return BOOLEAN
+ */
+BOOLEAN
+HyperDbgEnableTransparentMode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId)
+{
+    return HyperDbgEnableTransparentModeEx(ProcessId, ProcessName, IsProcessId, 0);
+}
+
+/**
  * @brief !hide command handler
  *
  * @param CommandTokens
@@ -380,7 +405,7 @@ CommandHide(vector<CommandToken> CommandTokens, string Command)
 
 #endif
 
-    if (CommandTokens.size() <= 2 && CommandTokens.size() != 1)
+    if (CommandTokens.size() != 1 && CommandTokens.size() != 3)
     {
         ShowMessages("incorrect use of the '%s'\n\n",
                      GetCaseSensitiveStringFromCommandToken(CommandTokens.at(0)).c_str());

--- a/hyperdbg/libhyperdbg/code/export/export.cpp
+++ b/hyperdbg/libhyperdbg/code/export/export.cpp
@@ -1,6 +1,7 @@
 /**
  * @file export.cpp
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief Exported functions from libhyperdbg interface
  * @details
  * @version 0.10
@@ -831,6 +832,21 @@ BOOLEAN
 hyperdbg_u_enable_transparent_mode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId)
 {
     return HyperDbgEnableTransparentMode(ProcessId, ProcessName, IsProcessId);
+}
+
+/**
+ * @brief Enable transparent mode with a feature mask
+ * @param ProcessId The process ID to enable transparent mode for
+ * @param ProcessName The process name to enable transparent mode for
+ * @param IsProcessId If true, ProcessId is used, otherwise ProcessName is used
+ * @param EvadeMask The transparent-mode feature mask, or zero for default behavior
+ *
+ * @return BOOLEAN
+ */
+BOOLEAN
+hyperdbg_u_enable_transparent_mode_ex(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId, UINT32 EvadeMask)
+{
+    return HyperDbgEnableTransparentModeEx(ProcessId, ProcessName, IsProcessId, EvadeMask);
 }
 
 /**

--- a/hyperdbg/libhyperdbg/header/debugger.h
+++ b/hyperdbg/libhyperdbg/header/debugger.h
@@ -1,6 +1,7 @@
 /**
  * @file debugger.h
  * @author Sina Karvandi (sina@hyperdbg.org)
+ * @author jtaw5649
  * @brief General debugger functions
  * @details
  * @version 0.1
@@ -309,6 +310,9 @@ HyperDbgPerformSmiOperation(SMI_OPERATION_PACKETS * SmiOperation);
 
 BOOLEAN
 HyperDbgEnableTransparentMode(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId);
+
+BOOLEAN
+HyperDbgEnableTransparentModeEx(UINT32 ProcessId, CHAR * ProcessName, BOOLEAN IsProcessId, UINT32 EvadeMask);
 
 BOOLEAN
 HyperDbgDisableTransparentMode();


### PR DESCRIPTION
# Description

Add `hyperdbg_u_enable_transparent_mode_ex` so SDK callers can select
transparent-mode evade features with a mask while preserving the existing
default `hyperdbg_u_enable_transparent_mode` behavior.

The mask supports the current transparent-mode surfaces, allows callers to skip
the syscall hook, and rejects unknown bits before enabling transparent mode.


## Testing

- loaded `hyperkd.sys`
- ran `status` 
- verified mask `0` enables default transparent-mode behavior
- verified mask `0x0f` enables all current transparent-mode evade surfaces
- verified mask `0x0e` enables transparent mode with the syscall hook bit cleared
- verified mask `0x10` is rejected as an unknown mask bit
- verified each successful enable path disables cleanly
- verified final unload, stop, and uninstall complete cleanly

## Type of change

- [x] New feature (non-breaking change which adds functionality)