### PR TITLE
Linux added new platform independent functions to the API

### DIFF
--- a/hyperdbg/include/platform/general/header/Environment.h
+++ b/hyperdbg/include/platform/general/header/Environment.h
@@ -75,4 +75,7 @@ typedef void * HMODULE;
 #    define INFINITE      0xFFFFFFFF
 #    define WAIT_OBJECT_0 0x00000000
 
+// Win32 invalid handle sentinel (returned by the cross-platform file/serial wrappers)
+#    define INVALID_HANDLE_VALUE ((HANDLE)(SIZE_T)-1)
+
 #endif // HYPERDBG_ENV_LINUX

--- a/hyperdbg/include/platform/user/code/platform-lib-calls.c
+++ b/hyperdbg/include/platform/user/code/platform-lib-calls.c
@@ -1,6 +1,6 @@
 /**
  * @file platform-lib-calls.c
- * @author Max Raulea (max.raulea@gmail.com)
+ * @author Max Raulea (max.raulea@gmail.com) 
  * @brief User mode Cross platform APIs for platofrm dependend library calls
  * @details
  * @version 0.19

--- a/hyperdbg/include/platform/user/code/platform-lib-calls.c
+++ b/hyperdbg/include/platform/user/code/platform-lib-calls.c
@@ -447,3 +447,167 @@ PlatformCloseFile(HANDLE FileHandle)
 #    error "Unsupported platform"
 #endif
 }
+
+/**
+ * @brief Platform independent wrapper to map an entire file read-only into memory
+ *
+ * @details The returned pointer stays valid until released with PlatformUnmapFile;
+ *          the underlying file/descriptor is closed before returning (the mapping
+ *          outlives it on both platforms).
+ *
+ * @param Path wide path of the file to map
+ * @param OutFileSize output — size of the file in bytes (0 on failure)
+ * @return VOID* base address of the mapped file, or NULL on failure
+ */
+VOID *
+PlatformMapFileReadOnly(const wchar_t * Path, PSIZE_T OutFileSize, PHANDLE OutFileHandle)
+{
+#if defined(_WIN32)
+    HANDLE        FileHandle;
+    HANDLE        MapObjectHandle;
+    VOID *        BaseAddr;
+    LARGE_INTEGER FileSize;
+
+    *OutFileSize   = 0;
+    *OutFileHandle = INVALID_HANDLE_VALUE;
+
+    FileHandle = CreateFileW(Path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (FileHandle == INVALID_HANDLE_VALUE)
+    {
+        return NULL;
+    }
+
+    if (!GetFileSizeEx(FileHandle, &FileSize))
+    {
+        CloseHandle(FileHandle);
+        return NULL;
+    }
+
+    MapObjectHandle = CreateFileMapping(FileHandle, NULL, PAGE_READONLY, 0, 0, NULL);
+    if (MapObjectHandle == NULL)
+    {
+        CloseHandle(FileHandle);
+        return NULL;
+    }
+
+    BaseAddr = MapViewOfFile(MapObjectHandle, FILE_MAP_READ, 0, 0, 0);
+
+    //
+    // The view stays valid after the mapping object handle is closed. The file
+    // handle is kept open and handed back so the caller can still issue raw
+    // reads (PlatformReadFileAtOffset); it is closed by PlatformUnmapFile.
+    //
+    CloseHandle(MapObjectHandle);
+
+    if (BaseAddr == NULL)
+    {
+        CloseHandle(FileHandle);
+        return NULL;
+    }
+
+    *OutFileSize   = (SIZE_T)FileSize.QuadPart;
+    *OutFileHandle = FileHandle;
+    return BaseAddr;
+#elif defined(__linux__)
+    //
+    // TODO (linux): implement the real mapping. Expected contract:
+    //   1. Narrow the 4-byte wchar_t 'Path' to a UTF-8 char* (the project still
+    //      lacks a wchar_t->UTF-8 helper; the same one is needed by
+    //      PlatformOpenFileForWriting for the dump.cpp write path).
+    //   2. fd = open(narrowed_path, O_RDONLY);                  // fail -> NULL
+    //   3. fstat(fd, &st) to get the file size.
+    //   4. base = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    //   5. *OutFileHandle = (HANDLE)(intptr_t)fd;  // keep fd open for raw reads
+    //   6. *OutFileSize = st.st_size; return base;  (return NULL on any failure)
+    // PlatformUnmapFile must then munmap(base, size) and close the fd — which is
+    // why both the size and the handle are passed back in on unmap. The raw-read
+    // path (PlatformReadFileAtOffset) would pread() from that same fd.
+    //
+    // Until implemented, fail the map so PE-parser callers print "could not open
+    // the file" and bail out cleanly instead of dereferencing a bogus pointer.
+    //
+    (void)Path;
+    *OutFileSize   = 0;
+    *OutFileHandle = INVALID_HANDLE_VALUE;
+    return NULL;
+#else
+#    error "Unsupported platform"
+#endif
+}
+
+/**
+ * @brief Platform independent wrapper for a positioned (seek + read) file read
+ *
+ * @param FileHandle handle handed back by PlatformMapFileReadOnly
+ * @param Offset byte offset to read from (absolute, from start of file)
+ * @param Buffer destination buffer
+ * @param NumberOfBytes number of bytes to read
+ * @param BytesRead output — number of bytes actually read
+ * @return BOOLEAN TRUE on success
+ */
+BOOLEAN
+PlatformReadFileAtOffset(HANDLE FileHandle, UINT64 Offset, VOID * Buffer, DWORD NumberOfBytes, LPDWORD BytesRead)
+{
+#if defined(_WIN32)
+    LARGE_INTEGER Distance;
+    Distance.QuadPart = (LONGLONG)Offset;
+
+    if (!SetFilePointerEx(FileHandle, Distance, NULL, FILE_BEGIN))
+    {
+        return FALSE;
+    }
+
+    return (BOOLEAN)ReadFile(FileHandle, Buffer, NumberOfBytes, BytesRead, NULL);
+#elif defined(__linux__)
+    //
+    // TODO (linux): pread((int)(intptr_t)FileHandle, Buffer, NumberOfBytes, Offset)
+    //               once PlatformMapFileReadOnly wraps a real fd. Unreached today
+    //               because the map returns NULL on Linux, so callers bail first.
+    //
+    (void)FileHandle;
+    (void)Offset;
+    (void)Buffer;
+    (void)NumberOfBytes;
+    if (BytesRead != NULL)
+    {
+        *BytesRead = 0;
+    }
+    return FALSE;
+#else
+#    error "Unsupported platform"
+#endif
+}
+
+/**
+ * @brief Platform independent wrapper to release a mapping from PlatformMapFileReadOnly
+ *
+ * @param BaseAddress base address returned by PlatformMapFileReadOnly
+ * @param FileSize size that was reported by PlatformMapFileReadOnly (needed by munmap)
+ * @param FileHandle file handle handed back by PlatformMapFileReadOnly
+ */
+VOID
+PlatformUnmapFile(VOID * BaseAddress, SIZE_T FileSize, HANDLE FileHandle)
+{
+#if defined(_WIN32)
+    (void)FileSize; // not needed by UnmapViewOfFile
+    if (BaseAddress != NULL)
+    {
+        UnmapViewOfFile(BaseAddress);
+    }
+    if (FileHandle != INVALID_HANDLE_VALUE)
+    {
+        CloseHandle(FileHandle);
+    }
+#elif defined(__linux__)
+    //
+    // TODO (linux): munmap(BaseAddress, FileSize) and close the fd behind
+    //               FileHandle once PlatformMapFileReadOnly is implemented.
+    //               No-op for now since the map always returns NULL.
+    //
+    (void)BaseAddress;
+    (void)FileSize;
+    (void)FileHandle;
+#else
+#    error "Unsupported platform"
+#endif
+}

--- a/hyperdbg/include/platform/user/code/platform-lib-calls.c
+++ b/hyperdbg/include/platform/user/code/platform-lib-calls.c
@@ -357,3 +357,93 @@ PlatformGetLastError(VOID)
 #    error "Unsupported platform"
 #endif
 }
+
+/**
+ * @brief Platform independent wrapper to write raw bytes to the console
+ *
+ * @details Used to emit pre-encoded UTF-8 byte sequences (e.g. box-drawing
+ *          characters) directly to standard output. On Windows this goes
+ *          through WriteConsoleA so the console code page is bypassed; on
+ *          Linux the terminal is UTF-8 native so the bytes are written as-is.
+ *
+ * @param Buffer pointer to the bytes to write
+ * @param NumberOfBytes number of bytes to write
+ * @return BOOLEAN TRUE on success
+ */
+BOOLEAN
+PlatformWriteConsole(const VOID * Buffer, DWORD NumberOfBytes)
+{
+#if defined(_WIN32)
+    return (BOOLEAN)WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), Buffer, NumberOfBytes, NULL, NULL);
+#elif defined(__linux__)
+    return (BOOLEAN)(fwrite(Buffer, 1, NumberOfBytes, stdout) == NumberOfBytes);
+#else
+#    error "Unsupported platform"
+#endif
+}
+
+/**
+ * @brief Platform independent wrapper to create/open a file for writing
+ *
+ * @param Path wide path of the file to create (truncated if it exists)
+ * @return HANDLE to the opened file, or INVALID_HANDLE_VALUE on failure
+ */
+HANDLE
+PlatformOpenFileForWriting(const wchar_t * Path)
+{
+#if defined(_WIN32)
+    return CreateFileW(Path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+#elif defined(__linux__)
+    //
+    // TODO: handle this later. The path arrives as a std::wstring (4-byte
+    //       wchar_t on Linux) and must be narrowed to a UTF-8 char* before it
+    //       can be handed to fopen. Until that conversion is wired up, fail the
+    //       open so callers (e.g. dump.cpp) bail out cleanly instead of writing
+    //       to a bogus handle.
+    //
+    (void)Path;
+    return INVALID_HANDLE_VALUE;
+#else
+#    error "Unsupported platform"
+#endif
+}
+
+/**
+ * @brief Platform independent wrapper to write a buffer to an open file
+ *
+ * @param FileHandle handle returned by PlatformOpenFileForWriting
+ * @param Buffer pointer to the bytes to write
+ * @param NumberOfBytes number of bytes to write
+ * @return BOOLEAN TRUE on success
+ */
+BOOLEAN
+PlatformWriteFile(HANDLE FileHandle, const VOID * Buffer, DWORD NumberOfBytes)
+{
+#if defined(_WIN32)
+    DWORD BytesWritten;
+    return (BOOLEAN)WriteFile(FileHandle, Buffer, NumberOfBytes, &BytesWritten, NULL);
+#elif defined(__linux__)
+    return (BOOLEAN)(fwrite(Buffer, 1, NumberOfBytes, (FILE *)FileHandle) == NumberOfBytes);
+#else
+#    error "Unsupported platform"
+#endif
+}
+
+/**
+ * @brief Platform independent wrapper to close a file opened by
+ *        PlatformOpenFileForWriting
+ *
+ * @param FileHandle handle to close
+ * @return BOOLEAN TRUE on success
+ */
+BOOLEAN
+PlatformCloseFile(HANDLE FileHandle)
+{
+#if defined(_WIN32)
+    return (BOOLEAN)CloseHandle(FileHandle);
+#elif defined(__linux__)
+    return (BOOLEAN)(fclose((FILE *)FileHandle) == 0);
+#else
+#    error "Unsupported platform"
+#endif
+}

--- a/hyperdbg/include/platform/user/code/platform-lib-calls.c
+++ b/hyperdbg/include/platform/user/code/platform-lib-calls.c
@@ -389,7 +389,7 @@ PlatformWriteConsole(const VOID * Buffer, DWORD NumberOfBytes)
  * @return HANDLE to the opened file, or INVALID_HANDLE_VALUE on failure
  */
 HANDLE
-PlatformOpenFileForWriting(const wchar_t * Path)
+PlatformOpenFileForWriting(const WCHAR * Path)
 {
 #if defined(_WIN32)
     return CreateFileW(Path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -460,7 +460,7 @@ PlatformCloseFile(HANDLE FileHandle)
  * @return VOID* base address of the mapped file, or NULL on failure
  */
 VOID *
-PlatformMapFileReadOnly(const wchar_t * Path, PSIZE_T OutFileSize, PHANDLE OutFileHandle)
+PlatformMapFileReadOnly(const WCHAR * Path, PSIZE_T OutFileSize, PHANDLE OutFileHandle)
 {
 #if defined(_WIN32)
     HANDLE        FileHandle;

--- a/hyperdbg/include/platform/user/header/platform-lib-calls.h
+++ b/hyperdbg/include/platform/user/header/platform-lib-calls.h
@@ -106,6 +106,22 @@ BOOLEAN
 PlatformCloseFile(HANDLE FileHandle);
 
 //
+// READ-ONLY FILE MAPPING
+//
+// PlatformMapFileReadOnly also hands back the still-open file handle in
+// *OutFileHandle, so callers can issue supplementary raw reads via
+// PlatformReadFileAtOffset; release everything with PlatformUnmapFile.
+//
+VOID *
+PlatformMapFileReadOnly(const wchar_t * Path, PSIZE_T OutFileSize, PHANDLE OutFileHandle);
+
+BOOLEAN
+PlatformReadFileAtOffset(HANDLE FileHandle, UINT64 Offset, VOID * Buffer, DWORD NumberOfBytes, LPDWORD BytesRead);
+
+VOID
+PlatformUnmapFile(VOID * BaseAddress, SIZE_T FileSize, HANDLE FileHandle);
+
+//
 // PROCESS / THREAD IDENTITY
 //
 UINT32

--- a/hyperdbg/include/platform/user/header/platform-lib-calls.h
+++ b/hyperdbg/include/platform/user/header/platform-lib-calls.h
@@ -72,8 +72,38 @@ PlatformCloseHandle(HANDLE Handle);
 //
 // LAST OS ERROR
 //
+// TODO (linux, correctness): the wrappers below only unify the success/failure
+// *boolean* convention. The actual error semantics still differ across platforms
+// and must be reconciled later:
+//   - PlatformGetLastError returns raw Linux errno (EACCES=13, ...) which does NOT
+//     match the Win32 ERROR_* code space (ERROR_ACCESS_DENIED=5, ...). Code that
+//     merely logs/checks-nonzero is fine; code that compares against ERROR_* needs
+//     an errno -> ERROR_* mapping here.
+//   - Failure sentinels are not uniform across the Win32 calls we wrap: file opens
+//     fail with INVALID_HANDLE_VALUE (not NULL), most other handle calls fail with
+//     NULL. Callers must test the right one.
+// For now: getting the project to compile is step 1; correctness comes next.
+//
 DWORD
 PlatformGetLastError(VOID);
+
+//
+// CONSOLE OUTPUT (raw bytes to stdout)
+//
+BOOLEAN
+PlatformWriteConsole(const VOID * Buffer, DWORD NumberOfBytes);
+
+//
+// FILE I/O
+//
+HANDLE
+PlatformOpenFileForWriting(const wchar_t * Path);
+
+BOOLEAN
+PlatformWriteFile(HANDLE FileHandle, const VOID * Buffer, DWORD NumberOfBytes);
+
+BOOLEAN
+PlatformCloseFile(HANDLE FileHandle);
 
 //
 // PROCESS / THREAD IDENTITY

--- a/hyperdbg/include/platform/user/header/platform-lib-calls.h
+++ b/hyperdbg/include/platform/user/header/platform-lib-calls.h
@@ -97,7 +97,7 @@ PlatformWriteConsole(const VOID * Buffer, DWORD NumberOfBytes);
 // FILE I/O
 //
 HANDLE
-PlatformOpenFileForWriting(const wchar_t * Path);
+PlatformOpenFileForWriting(const WCHAR * Path);
 
 BOOLEAN
 PlatformWriteFile(HANDLE FileHandle, const VOID * Buffer, DWORD NumberOfBytes);
@@ -113,7 +113,7 @@ PlatformCloseFile(HANDLE FileHandle);
 // PlatformReadFileAtOffset; release everything with PlatformUnmapFile.
 //
 VOID *
-PlatformMapFileReadOnly(const wchar_t * Path, PSIZE_T OutFileSize, PHANDLE OutFileHandle);
+PlatformMapFileReadOnly(const WCHAR * Path, PSIZE_T OutFileSize, PHANDLE OutFileHandle);
 
 BOOLEAN
 PlatformReadFileAtOffset(HANDLE FileHandle, UINT64 Offset, VOID * Buffer, DWORD NumberOfBytes, LPDWORD BytesRead);

--- a/hyperdbg/libhyperdbg/code/debugger/commands/extension-commands/track.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/extension-commands/track.cpp
@@ -244,7 +244,7 @@ CommandTrackHandleReceivedCallInstructions(const CHAR * NameOfFunctionFromSymbol
 
     for (SIZE_T i = 0; i < NumberOfCallsIdentation; i++)
     {
-        WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), Utf8String1, sizeof(Utf8String1) - 1, NULL, NULL);
+        PlatformWriteConsole(Utf8String1, sizeof(Utf8String1) - 1);
     }
 
     //
@@ -252,7 +252,7 @@ CommandTrackHandleReceivedCallInstructions(const CHAR * NameOfFunctionFromSymbol
     //
     // CHAR Utf8String[] = "\xE2\x94\x9C\xE2\x94\x80\xE2\x94\x80";
     CHAR Utf8String[] = "\xE2\x94\x8C\xE2\x94\x80\xE2\x94\x80";
-    WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), Utf8String, sizeof(Utf8String) - 1, NULL, NULL);
+    PlatformWriteConsole(Utf8String, sizeof(Utf8String) - 1);
 
     if (NameOfFunctionFromSymbols != NULL)
     {
@@ -296,14 +296,14 @@ CommandTrackHandleReceivedRetInstructions(UINT64 CurrentRip)
 
     for (SIZE_T i = 0; i < NumberOfCallsIdentation; i++)
     {
-        WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), Utf8String1, sizeof(Utf8String1) - 1, NULL, NULL);
+        PlatformWriteConsole(Utf8String1, sizeof(Utf8String1) - 1);
     }
 
     //
     // Write the UTF-8 encoded character sequence to the console
     //
     CHAR Utf8String[] = "\xE2\x94\x94\xE2\x94\x80\xE2\x94\x80\x20";
-    WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), Utf8String, sizeof(Utf8String) - 1, NULL, NULL);
+    PlatformWriteConsole(Utf8String, sizeof(Utf8String) - 1);
 
     //
     // Apply addressconversion of settings here

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/dump.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/dump.cpp
@@ -226,7 +226,19 @@ CommandDump(vector<CommandToken> CommandTokens, string Command)
     //
     // Create or open the file for writing the dump file
     //
+    // TEMPORARY LINUX SHIM (same as in pe.cpp): std::wstring stores native
+    // wchar_t (4 bytes on Linux), but the HyperDbg WCHAR type is 2 bytes
+    // (UINT16) and PlatformOpenFileForWriting takes a const WCHAR *. On Linux
+    // the cast is a bogus 2-byte reinterpretation, acceptable only because
+    // Linux file I/O is still stubbed (the path is never opened). On Windows
+    // WCHAR == wchar_t, so it is a plain correct pointer. TODO(Linux): remove
+    // once real file I/O lands and convert wchar_t -> 2-byte WCHAR properly.
+    //
+#ifdef __linux__
+    DumpFileHandle = PlatformOpenFileForWriting((const WCHAR *)Filepath.c_str());
+#else
     DumpFileHandle = PlatformOpenFileForWriting(Filepath.c_str());
+#endif
 
     if (DumpFileHandle == INVALID_HANDLE_VALUE)
     {

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/dump.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/dump.cpp
@@ -212,7 +212,7 @@ CommandDump(vector<CommandToken> CommandTokens, string Command)
         //
         // Default process we read from current process
         //
-        Pid = GetCurrentProcessId();
+        Pid = PlatformGetCurrentProcessId();
     }
 
     //
@@ -226,14 +226,7 @@ CommandDump(vector<CommandToken> CommandTokens, string Command)
     //
     // Create or open the file for writing the dump file
     //
-    DumpFileHandle = CreateFileW(
-        Filepath.c_str(),
-        GENERIC_WRITE,
-        0,
-        NULL,
-        CREATE_ALWAYS,
-        FILE_ATTRIBUTE_NORMAL,
-        NULL);
+    DumpFileHandle = PlatformOpenFileForWriting(Filepath.c_str());
 
     if (DumpFileHandle == INVALID_HANDLE_VALUE)
     {
@@ -284,7 +277,7 @@ CommandDump(vector<CommandToken> CommandTokens, string Command)
     //
     if (DumpFileHandle != NULL)
     {
-        CloseHandle(DumpFileHandle);
+        PlatformCloseFile(DumpFileHandle);
         DumpFileHandle = NULL;
     }
 
@@ -302,8 +295,6 @@ CommandDump(vector<CommandToken> CommandTokens, string Command)
 VOID
 CommandDumpSaveIntoFile(PVOID Buffer, UINT32 Length)
 {
-    DWORD BytesWritten;
-
     //
     // Check if handle is valid
     //
@@ -316,11 +307,11 @@ CommandDumpSaveIntoFile(PVOID Buffer, UINT32 Length)
     //
     // Write the buffer into the dump file
     //
-    if (!WriteFile(DumpFileHandle, Buffer, Length, &BytesWritten, NULL))
+    if (!PlatformWriteFile(DumpFileHandle, Buffer, Length))
     {
         ShowMessages("err, unable to write buffer into the dump\n");
 
-        CloseHandle(DumpFileHandle);
+        PlatformCloseFile(DumpFileHandle);
         DumpFileHandle = NULL;
 
         return;

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/pagein.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/pagein.cpp
@@ -216,14 +216,14 @@ CommandPageinRequest(UINT64               TargetVirtualAddrFrom,
 
         if (Pid == 0)
         {
-            Pid                        = GetCurrentProcessId();
+            Pid                        = PlatformGetCurrentProcessId();
             PageFaultRequest.ProcessId = Pid;
         }
 
         //
         // Send IOCTL
         //
-        Status = DeviceIoControl(
+        Status = PlatformDeviceIoControl(
             g_DeviceHandle,                  // Handle to device
             IOCTL_DEBUGGER_BRING_PAGES_IN,   // IO Control Code (IOCTL)
             &PageFaultRequest,               // Input Buffer to driver.
@@ -237,7 +237,7 @@ CommandPageinRequest(UINT64               TargetVirtualAddrFrom,
 
         if (!Status)
         {
-            ShowMessages("ioctl failed with code 0x%x\n", GetLastError());
+            ShowMessages("ioctl failed with code 0x%x\n", PlatformGetLastError());
             return;
         }
 

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/pe.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/pe.cpp
@@ -107,9 +107,31 @@ CommandPe(vector<CommandToken> CommandTokens, string Command)
     StringToWString(Filepath, TempFilePath);
 
     //
+    // TEMPORARY LINUX SHIM:
+    //   std::wstring stores native wchar_t, which is 4 bytes on Linux, but the
+    //   HyperDbg WCHAR type is 2 bytes (UINT16) and the PE-parser path APIs take
+    //   a const WCHAR *. The cast below exists ONLY so the project compiles on
+    //   Linux. On Linux it produces a bogus 2-byte reinterpretation of the 4-byte
+    //   buffer; that is acceptable for now only because Linux file I/O is still
+    //   stubbed (the path is never actually opened). On Windows WCHAR == wchar_t,
+    //   so it is a plain, correct pointer with no reinterpretation.
+    //
+    //   TODO (Linux): remove this cast once real Linux file I/O lands. The proper
+    //   fix is to convert the 4-byte wchar_t path into a 2-byte WCHAR/UTF-16
+    //   buffer (e.g. a std::wstring -> WCHAR helper) and pass that, so the PE
+    //   parser receives a valid path. The same conversion is needed by
+    //   PlatformMapFileReadOnly / PlatformOpenFileForWriting.
+    //
+#ifdef __linux__
+    const WCHAR * FilepathW = (const WCHAR *)Filepath.c_str();
+#else
+    const WCHAR * FilepathW = Filepath.c_str();
+#endif
+
+    //
     // Detect whether PE is 32-bit or 64-bit
     //
-    if (!PeIsPE32BitOr64Bit(Filepath.c_str(), &Is32Bit))
+    if (!PeIsPE32BitOr64Bit(FilepathW, &Is32Bit))
     {
         //
         // File was invalid, the error message is shown in the above function
@@ -122,10 +144,10 @@ CommandPe(vector<CommandToken> CommandTokens, string Command)
     //
     if (!ShowDumpOfSection)
     {
-        PeShowSectionInformationAndDump(Filepath.c_str(), NULL, Is32Bit);
+        PeShowSectionInformationAndDump(FilepathW, NULL, Is32Bit);
     }
     else
     {
-        PeShowSectionInformationAndDump(Filepath.c_str(), GetCaseSensitiveStringFromCommandToken(CommandTokens.at(2)).c_str(), Is32Bit);
+        PeShowSectionInformationAndDump(FilepathW, GetCaseSensitiveStringFromCommandToken(CommandTokens.at(2)).c_str(), Is32Bit);
     }
 }

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/restart.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/restart.cpp
@@ -89,15 +89,33 @@ CommandRestart(vector<CommandToken> CommandTokens, string Command)
     //
     if (g_StartCommandPathAndArguments.empty())
     {
+        //
+        // TEMPORARY LINUX SHIM (same as in pe.cpp/dump.cpp): the path is a
+        // std::wstring of native wchar_t (4 bytes on Linux), but UdAttachToProcess
+        // takes a 2-byte HyperDbg WCHAR * (UINT16). The cast is a bogus 2-byte
+        // reinterpretation on Linux, acceptable only because the user-debugger
+        // path is still stubbed there. On Windows WCHAR == wchar_t, so it is a
+        // plain correct pointer. TODO(Linux): convert wchar_t -> 2-byte WCHAR
+        // properly once the Linux user-debugger path is real.
+        //
         UdAttachToProcess(NULL,
-                          g_StartCommandPath.c_str(),
+                          (WCHAR *)g_StartCommandPath.c_str(),
                           NULL,
                           FALSE);
     }
     else
     {
+        //
+        // TEMPORARY LINUX SHIM (same as in pe.cpp/dump.cpp): the path/arguments
+        // are std::wstring of native wchar_t (4 bytes on Linux), but
+        // UdAttachToProcess takes 2-byte HyperDbg WCHAR * (UINT16). The casts are
+        // a bogus 2-byte reinterpretation on Linux, acceptable only because the
+        // user-debugger path is still stubbed there. On Windows WCHAR == wchar_t,
+        // so they are plain correct pointers. TODO(Linux): convert wchar_t ->
+        // 2-byte WCHAR properly once the Linux user-debugger path is real.
+        //
         UdAttachToProcess(NULL,
-                          g_StartCommandPath.c_str(),
+                          (WCHAR *)g_StartCommandPath.c_str(),
                           (WCHAR *)g_StartCommandPathAndArguments.c_str(),
                           FALSE);
     }

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/start.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/start.cpp
@@ -147,8 +147,17 @@ CommandStart(vector<CommandToken> CommandTokens, string Command)
     //
     if (Arguments.empty())
     {
+        //
+        // TEMPORARY LINUX SHIM (same as in pe.cpp/dump.cpp): the path is a
+        // std::wstring of native wchar_t (4 bytes on Linux), but UdAttachToProcess
+        // takes a 2-byte HyperDbg WCHAR * (UINT16). The cast is a bogus 2-byte
+        // reinterpretation on Linux, acceptable only because the user-debugger
+        // path is still stubbed there. On Windows WCHAR == wchar_t, so it is a
+        // plain correct pointer. TODO(Linux): convert wchar_t -> 2-byte WCHAR
+        // properly once the Linux user-debugger path is real.
+        //
         UdAttachToProcess(NULL,
-                          g_StartCommandPath.c_str(),
+                          (WCHAR *)g_StartCommandPath.c_str(),
                           NULL,
                           FALSE);
     }
@@ -164,8 +173,17 @@ CommandStart(vector<CommandToken> CommandTokens, string Command)
         //
         StringToWString(g_StartCommandPathAndArguments, Arguments);
 
+        //
+        // TEMPORARY LINUX SHIM (same as in pe.cpp/dump.cpp): the path/arguments
+        // are std::wstring of native wchar_t (4 bytes on Linux), but
+        // UdAttachToProcess takes 2-byte HyperDbg WCHAR * (UINT16). The casts are
+        // a bogus 2-byte reinterpretation on Linux, acceptable only because the
+        // user-debugger path is still stubbed there. On Windows WCHAR == wchar_t,
+        // so they are plain correct pointers. TODO(Linux): convert wchar_t ->
+        // 2-byte WCHAR properly once the Linux user-debugger path is real.
+        //
         UdAttachToProcess(NULL,
-                          g_StartCommandPath.c_str(),
+                          (WCHAR *)g_StartCommandPath.c_str(),
                           (WCHAR *)g_StartCommandPathAndArguments.c_str(),
                           FALSE);
     }

--- a/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
@@ -3724,9 +3724,9 @@ PeHexDump(CHAR * Ptr, SIZE_T Size, ULONGLONG SecAddress)
  * @return BOOLEAN
  */
 BOOLEAN
-PeShowSectionInformationAndDump(const WCHAR * AddressOfFile,
-                                const CHAR *  SectionToShow,
-                                BOOLEAN       Is32Bit)
+PeShowSectionInformationAndDump(const wchar_t * AddressOfFile,
+                                const CHAR *    SectionToShow,
+                                BOOLEAN         Is32Bit)
 {
     RICH_HEADER_INFO             PeFileRichHeaderInfo {0};
     RICH_HEADER                  PeFileRichHeader {0};
@@ -3738,7 +3738,8 @@ PeShowSectionInformationAndDump(const WCHAR * AddressOfFile,
     const ULONGLONG              MaxTotalSectionScanBytes = 64 * 1024 * 1024;
     const SIZE_T                 MaxSectionDumpBytes      = 1024 * 1024;
     const ULONGLONG              MaxTotalSectionDumpBytes = 4 * 1024 * 1024;
-    HANDLE                       MapObjectHandle = NULL, FileHandle = INVALID_HANDLE_VALUE; // File Mapping Object
+    HANDLE                       FileHandle = INVALID_HANDLE_VALUE;                         // Open file handle (kept for the raw Rich-header read)
+    SIZE_T                       MappedSize = 0;                                            // Size of the mapped file in bytes
     UINT32                       NumberOfSections;                                          // Number of sections
     LPVOID                       BaseAddr = NULL;                                           // Pointer to the base memory of mapped file
     PIMAGE_DOS_HEADER            DosHeader;                                                 // Pointer to DOS Header
@@ -3760,39 +3761,22 @@ PeShowSectionInformationAndDump(const WCHAR * AddressOfFile,
     time_t                       TimeDateStamp;
 
     //
-    // Open the EXE File
+    // Open and map the EXE file read-only. The wrapper also hands back the open
+    // file handle so the raw Rich-header read below can still seek/read it.
     //
-    FileHandle = CreateFileW(AddressOfFile, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    BaseAddr = PlatformMapFileReadOnly(AddressOfFile, &MappedSize, &FileHandle);
 
-    if (FileHandle == INVALID_HANDLE_VALUE)
+    if (BaseAddr == NULL)
     {
         ShowMessages("err, could not open the file specified\n");
         return FALSE;
     }
 
-    if (!GetFileSizeEx(FileHandle, &FileSize) || FileSize.QuadPart < (LONGLONG)sizeof(IMAGE_DOS_HEADER))
+    FileSize.QuadPart = (LONGLONG)MappedSize;
+
+    if (FileSize.QuadPart < (LONGLONG)sizeof(IMAGE_DOS_HEADER))
     {
-        CloseHandle(FileHandle);
-        return FALSE;
-    }
-
-    //
-    // Mapping Given EXE file to Memory
-    //
-    MapObjectHandle = CreateFileMapping(FileHandle, NULL, PAGE_READONLY, 0, 0, NULL);
-
-    if (MapObjectHandle == NULL)
-    {
-        CloseHandle(FileHandle);
-        return FALSE;
-    }
-
-    BaseAddr = MapViewOfFile(MapObjectHandle, FILE_MAP_READ, 0, 0, 0);
-
-    if (BaseAddr == NULL)
-    {
-        CloseHandle(MapObjectHandle);
-        CloseHandle(FileHandle);
+        PlatformUnmapFile(BaseAddr, MappedSize, FileHandle);
         return FALSE;
     }
 
@@ -3843,15 +3827,7 @@ PeShowSectionInformationAndDump(const WCHAR * AddressOfFile,
                 goto SkipRichHeader;
             }
 
-            if (!SetFilePointerEx(FileHandle, FileStart, NULL, FILE_BEGIN))
-            {
-                RichHeaderStatus = "read failed";
-                delete[] DataPtr;
-                goto SkipRichHeader;
-            }
-
-            BOOL Result = ReadFile(FileHandle, DataPtr, RichReadSize, &BytesRead, NULL);
-            if (!Result || BytesRead != RichReadSize)
+            if (!PlatformReadFileAtOffset(FileHandle, 0, DataPtr, RichReadSize, &BytesRead) || BytesRead != RichReadSize)
             {
                 RichHeaderStatus = "read failed";
                 delete[] DataPtr;
@@ -4491,20 +4467,7 @@ Finished:
         delete[] PeFileRichHeader.Entries;
     }
 
-    if (BaseAddr != NULL)
-    {
-        UnmapViewOfFile(BaseAddr);
-    }
-
-    if (MapObjectHandle != NULL)
-    {
-        CloseHandle(MapObjectHandle);
-    }
-
-    if (FileHandle != INVALID_HANDLE_VALUE)
-    {
-        CloseHandle(FileHandle);
-    }
+    PlatformUnmapFile(BaseAddr, MappedSize, FileHandle);
 
     return Result;
 }
@@ -4517,54 +4480,33 @@ Finished:
  * @return BOOLEAN
  */
 BOOLEAN
-PeIsPE32BitOr64Bit(const WCHAR * AddressOfFile, PBOOLEAN Is32Bit)
+PeIsPE32BitOr64Bit(const wchar_t * AddressOfFile, PBOOLEAN Is32Bit)
 {
-    BOOLEAN             Result = FALSE;
-    HANDLE              MapObjectHandle, FileHandle; // File Mapping Object
-    LPVOID              BaseAddr;                    // Pointer to the base memory of mapped file
+    BOOLEAN             Result     = FALSE;
+    HANDLE              FileHandle = INVALID_HANDLE_VALUE; // Open file handle
+    SIZE_T              MappedSize = 0;                    // Size of the mapped file in bytes
+    LPVOID              BaseAddr;                          // Pointer to the base memory of mapped file
     PIMAGE_DOS_HEADER   DosHeader;                   // Pointer to DOS Header
     PIMAGE_NT_HEADERS32 NtHeader32 = NULL;           // Pointer to NT Header 32 bit
     PE_IMAGE_READER     Reader;
     LARGE_INTEGER       FileSize;
 
     //
-    // Open the EXE File
+    // Open and map the EXE file read-only
     //
-    FileHandle = CreateFileW(AddressOfFile, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    if (FileHandle == INVALID_HANDLE_VALUE)
-    {
-        ShowMessages("err, unable to read the file (%x)\n", GetLastError());
-        return FALSE;
-    };
-
-    if (!GetFileSizeEx(FileHandle, &FileSize) || FileSize.QuadPart < (LONGLONG)sizeof(IMAGE_DOS_HEADER))
-    {
-        CloseHandle(FileHandle);
-        return FALSE;
-    }
-
-    //
-    // Mapping Given EXE file to Memory
-    //
-    MapObjectHandle =
-        CreateFileMapping(FileHandle, NULL, PAGE_READONLY, 0, 0, NULL);
-
-    if (MapObjectHandle == NULL)
-    {
-        CloseHandle(FileHandle);
-
-        ShowMessages("err, unable to create file mappings (%x)\n", GetLastError());
-        return FALSE;
-    }
-
-    BaseAddr = MapViewOfFile(MapObjectHandle, FILE_MAP_READ, 0, 0, 0);
+    BaseAddr = PlatformMapFileReadOnly(AddressOfFile, &MappedSize, &FileHandle);
 
     if (BaseAddr == NULL)
     {
-        CloseHandle(MapObjectHandle);
-        CloseHandle(FileHandle);
+        ShowMessages("err, unable to read or map the file (%x)\n", PlatformGetLastError());
+        return FALSE;
+    }
 
-        ShowMessages("err, unable to create map view of file (%x)\n", GetLastError());
+    FileSize.QuadPart = (LONGLONG)MappedSize;
+
+    if (FileSize.QuadPart < (LONGLONG)sizeof(IMAGE_DOS_HEADER))
+    {
+        PlatformUnmapFile(BaseAddr, MappedSize, FileHandle);
         return FALSE;
     }
 
@@ -4649,9 +4591,7 @@ Finished:
     //
     // Unmap and close the handles
     //
-    UnmapViewOfFile(BaseAddr);
-    CloseHandle(MapObjectHandle);
-    CloseHandle(FileHandle);
+    PlatformUnmapFile(BaseAddr, MappedSize, FileHandle);
 
     return Result;
 }

--- a/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/user-level/pe-parser.cpp
@@ -3724,9 +3724,9 @@ PeHexDump(CHAR * Ptr, SIZE_T Size, ULONGLONG SecAddress)
  * @return BOOLEAN
  */
 BOOLEAN
-PeShowSectionInformationAndDump(const wchar_t * AddressOfFile,
-                                const CHAR *    SectionToShow,
-                                BOOLEAN         Is32Bit)
+PeShowSectionInformationAndDump(const WCHAR * AddressOfFile,
+                                const CHAR *  SectionToShow,
+                                BOOLEAN       Is32Bit)
 {
     RICH_HEADER_INFO             PeFileRichHeaderInfo {0};
     RICH_HEADER                  PeFileRichHeader {0};
@@ -4480,7 +4480,7 @@ Finished:
  * @return BOOLEAN
  */
 BOOLEAN
-PeIsPE32BitOr64Bit(const wchar_t * AddressOfFile, PBOOLEAN Is32Bit)
+PeIsPE32BitOr64Bit(const WCHAR * AddressOfFile, PBOOLEAN Is32Bit)
 {
     BOOLEAN             Result     = FALSE;
     HANDLE              FileHandle = INVALID_HANDLE_VALUE; // Open file handle

--- a/hyperdbg/libhyperdbg/header/pe-parser.h
+++ b/hyperdbg/libhyperdbg/header/pe-parser.h
@@ -46,12 +46,12 @@ typedef struct _PE_RAW_SECTION_RANGE
 //////////////////////////////////////////////////
 
 BOOLEAN
-PeShowSectionInformationAndDump(const wchar_t * AddressOfFile,
-                                const CHAR *    SectionToShow,
-                                BOOLEAN         Is32Bit);
+PeShowSectionInformationAndDump(const WCHAR * AddressOfFile,
+                                const CHAR *  SectionToShow,
+                                BOOLEAN       Is32Bit);
 
 BOOLEAN
-PeIsPE32BitOr64Bit(const wchar_t * AddressOfFile, PBOOLEAN Is32Bit);
+PeIsPE32BitOr64Bit(const WCHAR * AddressOfFile, PBOOLEAN Is32Bit);
 
 UINT32
 PeGetSyscallNumber(LPCSTR NtFunctionName);

--- a/hyperdbg/libhyperdbg/header/pe-parser.h
+++ b/hyperdbg/libhyperdbg/header/pe-parser.h
@@ -46,12 +46,12 @@ typedef struct _PE_RAW_SECTION_RANGE
 //////////////////////////////////////////////////
 
 BOOLEAN
-PeShowSectionInformationAndDump(const WCHAR * AddressOfFile,
-                                const CHAR *  SectionToShow,
-                                BOOLEAN       Is32Bit);
+PeShowSectionInformationAndDump(const wchar_t * AddressOfFile,
+                                const CHAR *    SectionToShow,
+                                BOOLEAN         Is32Bit);
 
 BOOLEAN
-PeIsPE32BitOr64Bit(const WCHAR * AddressOfFile, PBOOLEAN Is32Bit);
+PeIsPE32BitOr64Bit(const wchar_t * AddressOfFile, PBOOLEAN Is32Bit);
 
 UINT32
 PeGetSyscallNumber(LPCSTR NtFunctionName);


### PR DESCRIPTION
# Description

Linux added new platform independent functions to the API and wchar linux windows mismatch handling, as a stub for now and needs extra fixing for later in the porting phase.



