### PR TITLE
Added VPID checking

### DIFF
--- a/hyperdbg/hyperhv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hyperhv/code/vmm/ept/Ept.c
@@ -23,7 +23,7 @@ EptCheckFeatures(VOID)
 {
     IA32_VMX_EPT_VPID_CAP_REGISTER VpidRegister;
     IA32_MTRR_DEF_TYPE_REGISTER    MTRRDefType;
-
+    g_IsVpidSupported   = FALSE;
     VpidRegister.AsUInt = CpuReadMsr(IA32_VMX_EPT_VPID_CAP);
     MTRRDefType.AsUInt  = CpuReadMsr(IA32_MTRR_DEF_TYPE);
 
@@ -35,6 +35,16 @@ EptCheckFeatures(VOID)
     if (!VpidRegister.AdvancedVmexitEptViolationsInformation)
     {
         LogDebugInfo("The processor doesn't report advanced VM-exit information for EPT violations");
+    }
+
+    if (VpidRegister.Invvpid &&
+        VpidRegister.InvvpidAllContexts &&
+        VpidRegister.InvvpidIndividualAddress &&
+        VpidRegister.InvvpidSingleContext &&
+        VpidRegister.InvvpidSingleContextRetainGlobals)
+    {
+        g_IsVpidSupported = TRUE;
+        LogDebugInfo("The processor supports VPID");
     }
 
     if (!VpidRegister.ExecuteOnlyPages)

--- a/hyperdbg/hyperhv/code/vmm/ept/Ept.c
+++ b/hyperdbg/hyperhv/code/vmm/ept/Ept.c
@@ -41,7 +41,8 @@ EptCheckFeatures(VOID)
         VpidRegister.InvvpidAllContexts &&
         VpidRegister.InvvpidIndividualAddress &&
         VpidRegister.InvvpidSingleContext &&
-        VpidRegister.InvvpidSingleContextRetainGlobals)
+        VpidRegister.InvvpidSingleContextRetainGlobals &&
+        !VmxIsTopLevelHypervisorHyperV())
     {
         g_IsVpidSupported = TRUE;
         LogDebugInfo("The processor supports VPID");

--- a/hyperdbg/hyperhv/code/vmm/ept/Vpid.c
+++ b/hyperdbg/hyperhv/code/vmm/ept/Vpid.c
@@ -25,6 +25,12 @@ VpidInvvpid(INVVPID_TYPE Type, INVVPID_DESCRIPTOR * Descriptor)
     INVVPID_DESCRIPTOR * TargetDescriptor = NULL;
     INVVPID_DESCRIPTOR   ZeroDescriptor   = {0};
 
+    // No need to do anything if VPID is not supported.
+    if (!g_IsVpidSupported)
+    {
+        return;
+    }
+
     if (!Descriptor)
     {
         TargetDescriptor = &ZeroDescriptor;

--- a/hyperdbg/hyperhv/code/vmm/vmx/Vmx.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/Vmx.c
@@ -1757,3 +1757,25 @@ VmxCompatibleMemcmp(const CHAR * Address1, const CHAR * Address2, SIZE_T Count)
     CpuWriteCr3(OriginalCr3.Flags);
     return Result;
 }
+
+/**
+ * @brief checks if the current top level hypervisor is Hyper-V
+ * 
+ *
+ * @return BOOLEAN TRUE indicates that the current top level hypervisor is Hyper-V, FALSE otherwise.
+ */
+BOOLEAN
+VmxIsTopLevelHypervisorHyperV() {
+    int processorFeatures[4] = {0};
+    __cpuidex(processorFeatures, CPUID_PROCESSOR_AND_PROCESSOR_FEATURE_IDENTIFIERS, 0);
+
+    if (!((ULONG)(processorFeatures[2]) & HYPERV_HYPERVISOR_PRESENT_BIT))
+        return FALSE;
+
+    int hypervisorVendor[4] = {0};
+    __cpuidex(hypervisorVendor, HYPERV_CPUID_VENDOR_AND_MAX_FUNCTIONS, 0);
+
+    return (ULONG)(hypervisorVendor[1]) == HYPERV_CPUID_VENDOR_MICROSOFT_EBX &&
+           (ULONG)(hypervisorVendor[2]) == HYPERV_CPUID_VENDOR_MICROSOFT_ECX &&
+           (ULONG)(hypervisorVendor[3]) == HYPERV_CPUID_VENDOR_MICROSOFT_EDX;
+}

--- a/hyperdbg/hyperhv/code/vmm/vmx/Vmx.c
+++ b/hyperdbg/hyperhv/code/vmm/vmx/Vmx.c
@@ -733,15 +733,17 @@ VmxSetupVmcs(VIRTUAL_MACHINE_STATE * VCpu, PVOID GuestStack)
     LogDebugInfo("CPU Based VM Exec Controls (Based on %s) : 0x%x",
                  VmxBasicMsr.VmxControls ? "IA32_VMX_TRUE_PROCBASED_CTLS" : "IA32_VMX_PROCBASED_CTLS",
                  CpuBasedVmExecControls);
+    UINT32 SecondaryProcBasedVmExecControlsFlags = IA32_VMX_PROCBASED_CTLS2_ENABLE_RDTSCP_FLAG |
+                                                   IA32_VMX_PROCBASED_CTLS2_ENABLE_EPT_FLAG |
+                                                   IA32_VMX_PROCBASED_CTLS2_ENABLE_INVPCID_FLAG |
+                                                   IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES_FLAG |
+                                                   IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE_FLAG;
 
-    SecondaryProcBasedVmExecControls = HvAdjustControls(
-        IA32_VMX_PROCBASED_CTLS2_ENABLE_RDTSCP_FLAG |
-            IA32_VMX_PROCBASED_CTLS2_ENABLE_EPT_FLAG |
-            IA32_VMX_PROCBASED_CTLS2_ENABLE_INVPCID_FLAG |
-            IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES_FLAG |
-            IA32_VMX_PROCBASED_CTLS2_ENABLE_VPID_FLAG |
-            IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE_FLAG,
-        IA32_VMX_PROCBASED_CTLS2);
+    if (g_IsVpidSupported)
+    {
+        SecondaryProcBasedVmExecControlsFlags |= IA32_VMX_PROCBASED_CTLS2_ENABLE_VPID_FLAG;
+    }
+    SecondaryProcBasedVmExecControls = HvAdjustControls(SecondaryProcBasedVmExecControlsFlags, IA32_VMX_PROCBASED_CTLS2);
 
     VmxVmwrite64(VMCS_CTRL_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS, SecondaryProcBasedVmExecControls);
 

--- a/hyperdbg/hyperhv/header/globals/GlobalVariables.h
+++ b/hyperdbg/hyperhv/header/globals/GlobalVariables.h
@@ -208,3 +208,8 @@ UINT64 g_PageFaultInjectionAddressTo;
  *
  */
 UINT32 g_PageFaultInjectionErrorCode;
+
+/**
+ * @brief Whether VPID is supported or not
+ */
+BOOLEAN g_IsVpidSupported;

--- a/hyperdbg/hyperhv/header/vmm/vmx/Vmx.h
+++ b/hyperdbg/hyperhv/header/vmm/vmx/Vmx.h
@@ -205,6 +205,12 @@ enum HYPERCALL_CODE
     HvCallFlushGuestPhysicalAddressList  = 0x00B0
 };
 
+/** @brief Hyper-V CPUID leaves
+*/
+#define HYPERV_CPUID_VENDOR_MICROSOFT_EBX 0x7263694d // "Micr"
+#define HYPERV_CPUID_VENDOR_MICROSOFT_ECX 0x666f736f // "osof"
+#define HYPERV_CPUID_VENDOR_MICROSOFT_EDX 0x76482074 // "t Hv"
+
 //////////////////////////////////////////////////
 //					Enums						//
 //////////////////////////////////////////////////
@@ -228,6 +234,9 @@ typedef enum _MOV_TO_DEBUG_REG
 //////////////////////////////////////////////////
 //					Functions					//
 //////////////////////////////////////////////////
+
+BOOLEAN
+VmxIsTopLevelHypervisorHyperV();
 
 BOOLEAN
 VmxCheckVmxSupport();


### PR DESCRIPTION
# Description

As a part of the process of making HyperDbg compatible with Hyper-V and since I had a lot of trouble with VPID when running Hyper-V I added a check that VPID can be enabled (instead of enabling it without a check) and ensuring that it isn't enabled under Hyper-V. 

If you want to keep VPID under Hyper-V, I can remove the check.
