### PR TITLE
Fix DRIVER_IRQL_NOT_LESS_OR_EQUAL when reading registers on a manually-halted core

### DIFF
--- a/hyperdbg/hyperhv/code/interface/Export.c
+++ b/hyperdbg/hyperhv/code/interface/Export.c
@@ -366,6 +366,18 @@ VmFuncGetLastVmexitRip(UINT32 CoreId)
 }
 
 /**
+ * @brief Get the guest's general-purpose registers of the target core
+ *
+ * @param CoreId Target core's ID
+ * @return GUEST_REGS *
+ */
+GUEST_REGS *
+VmFuncGetGuestRegs(UINT32 CoreId)
+{
+    return g_GuestState[CoreId].Regs;
+}
+
+/**
  * @brief Inject pending external interrupts
  *
  * @param CoreId Target core's ID

--- a/hyperdbg/hyperkd/code/debugger/commands/DebuggerCommands.c
+++ b/hyperdbg/hyperkd/code/debugger/commands/DebuggerCommands.c
@@ -25,6 +25,17 @@ DebuggerCommandReadRegisters(GUEST_REGS *                        Regs,
 {
     GUEST_EXTRA_REGISTERS ERegs = {0};
 
+    //
+    // Defense-in-depth: never dereference a NULL register context. The halt
+    // path is expected to provide the guest registers, but if it didn't, fail
+    // gracefully instead of bugchecking (DRIVER_IRQL_NOT_LESS_OR_EQUAL) at
+    // IRQL 0xff.
+    //
+    if (Regs == NULL)
+    {
+        return FALSE;
+    }
+
     if (ReadRegisterRequest->RegisterId == DEBUGGEE_SHOW_ALL_REGISTERS)
     {
         //

--- a/hyperdbg/hyperkd/code/debugger/core/DebuggerVmcalls.c
+++ b/hyperdbg/hyperkd/code/debugger/core/DebuggerVmcalls.c
@@ -39,6 +39,15 @@ DebuggerVmcallHandler(UINT32 CoreId,
     {
     case DEBUGGER_VMCALL_VM_EXIT_HALT_SYSTEM:
     {
+        //
+        // Unlike the event-triggered halt, the manual break/halt path does not
+        // carry a register context, so point the debugging state to this core's
+        // guest registers (saved on the last vm-exit). Without this, reading
+        // registers (e.g. the 'r' command) dereferences a NULL DbgState->Regs and
+        // bugchecks with DRIVER_IRQL_NOT_LESS_OR_EQUAL at IRQL 0xff.
+        //
+        DbgState->Regs = VmFuncGetGuestRegs(CoreId);
+
         KdHandleBreakpointAndDebugBreakpoints(DbgState,
                                               DEBUGGEE_PAUSING_REASON_REQUEST_FROM_DEBUGGER,
                                               NULL);

--- a/hyperdbg/hyperkd/code/debugger/kernel-level/Kd.c
+++ b/hyperdbg/hyperkd/code/debugger/kernel-level/Kd.c
@@ -1415,6 +1415,14 @@ KdHandleNmi(PROCESSOR_DEBUGGING_STATE * DbgState)
     SpinlockLock(&DbgState->Lock);
 
     //
+    // Cores halted via NMI don't carry a register context either, so make this
+    // core's guest registers (saved on the last vm-exit) available. Without this,
+    // reading registers on an NMI-halted core dereferences a NULL DbgState->Regs
+    // and bugchecks with DRIVER_IRQL_NOT_LESS_OR_EQUAL at IRQL 0xff.
+    //
+    DbgState->Regs = VmFuncGetGuestRegs(DbgState->CoreId);
+
+    //
     // All the cores should go and manage through the following function
     //
     KdManageSystemHaltOnVmxRoot(DbgState, NULL);

--- a/hyperdbg/include/SDK/imports/kernel/HyperDbgVmmImports.h
+++ b/hyperdbg/include/SDK/imports/kernel/HyperDbgVmmImports.h
@@ -214,6 +214,9 @@ VmFuncReadExceptionBitmap();
 IMPORT_EXPORT_VMM UINT64
 VmFuncGetLastVmexitRip(UINT32 CoreId);
 
+IMPORT_EXPORT_VMM GUEST_REGS *
+VmFuncGetGuestRegs(UINT32 CoreId);
+
 IMPORT_EXPORT_VMM UINT64
 VmFuncGetRflags();
 


### PR DESCRIPTION
## Problem

In Debugger Mode, breaking the debuggee (Ctrl+C) and then reading registers (e.g. the `r` command) can bugcheck the **debuggee** with `DRIVER_IRQL_NOT_LESS_OR_EQUAL` (0xD1) at IRQL 0xff. This matches the recurring reports in #30.

## Root cause

`DebuggerCommandReadRegisters()` copies `GUEST_REGS` from `DbgState->Regs`, but `DbgState->Regs` is only populated on the **event-triggered** halt paths (`DebuggerTriggerEvents()` and `DEBUGGER_VMCALL_VM_EXIT_HALT_SYSTEM_AS_A_RESULT_OF_TRIGGERING_EVENT`).

A core halted via a **manual break** (`DEBUGGER_VMCALL_VM_EXIT_HALT_SYSTEM`) or via the **NMI broadcast** (`KdHandleNmi`) never has `DbgState->Regs` set, so it is `NULL` and the `GUEST_REGS` `memcpy` dereferences address 0.

### Crash analysis (symbolized)

Two minidumps from bare-metal repros (v0.19 and v0.21 driver builds) both fault at the same place:

```
BugCheck D1, {0, ff, 0, fffff8031a8a83a8}
    Arg1: 0000000000000000   memory referenced (NULL)
    Arg2: 00000000000000ff   IRQL
    Arg3: 0000000000000000   0 = read operation
    Arg4: fffff8031a8a83a8   faulting instruction

fffff803`1a8a83a8  hyperkd!DebuggerCommandReadRegisters+0x1c:
fffff803`1a8a83a8  0f1001   movups  xmm0, xmmword ptr [rcx]     ; rcx = Regs = NULL
    [ hyperkd/code/debugger/commands/DebuggerCommands.c @ 33 ]  (the GUEST_REGS memcpy)

FAILURE_BUCKET_ID: DISABLED_INTERRUPT_FAULT_hyperkd!DebuggerCommandReadRegisters
```

(Raw minidumps available on request.)

## Fix

- Add `VmFuncGetGuestRegs(CoreId)` returning `g_GuestState[CoreId].Regs` (the guest GP registers saved on the last vm-exit), mirroring the existing `VmFuncGetLastVmexitRip`.
- Populate `DbgState->Regs` from it on the two manual-halt entry points (`DEBUGGER_VMCALL_VM_EXIT_HALT_SYSTEM` and `KdHandleNmi`) so register reads on a manually-halted core return the correct values.
- Add a defensive `NULL` check in `DebuggerCommandReadRegisters()`.

## Verification

Bare metal — Intel 9th-gen (Coffee Lake), Windows 11 24H2 (build 26100), serial Debugger Mode:

- **Before:** break + `r` reliably bugchecks the debuggee (`0xD1`).
- **After:** break + `r` returns the full register set, no crash:

```
4: kHyperDbg> r
RAX=0000000000000001 RBX=ffffd585eb1db200 RCX=0000000000000201
...
RIP=fffff80387e112f2 RSP=ffff878d2988f378 RBP=ffff878d2988f4d0
RFLAGS=0000000000040246
```

5 files changed, +43 lines. `clang-format` clean (per `hyperdbg/.clang-format`).
