### PR TITLE
Improve error handling for malformed command arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,15 @@ StructLayoutSettings.json
 .idea
 cmake-build-debug
 /hyperdbg/hyperhv/zydis/
+
+# CMake in-source build output
+# (hyperdbg/linux/README.md builds with `cmake .`, which generates these
+#  next to the sources; the Makefile rules are scoped to the directories
+#  that actually hold a CMakeLists.txt so the hand-written Makefiles under
+#  hyperdbg/linux/mock/ and hwdbg/sim/ stay tracked)
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+/hyperdbg/Makefile
+/hyperdbg/*/Makefile
+/examples/*/*/Makefile

--- a/hyperdbg/libhyperdbg/code/common/common.cpp
+++ b/hyperdbg/libhyperdbg/code/common/common.cpp
@@ -154,7 +154,7 @@ IsNumber(const string & str)
     // that does not match any of the characters specified in its arguments
     //
     return !str.empty() &&
-           (str.find_first_not_of("[0123456789]") == std::string::npos);
+           (str.find_first_not_of("0123456789") == std::string::npos);
 }
 
 /**
@@ -172,7 +172,11 @@ IsHexNotation(const string & s)
     {
         IsAnyThing = TRUE;
 
-        if (!isxdigit(CptrChar))
+        //
+        // The cast is needed as passing a negative 'char' to the <ctype.h>
+        // functions is undefined behavior
+        //
+        if (!isxdigit((UCHAR)CptrChar))
         {
             return FALSE;
         }
@@ -199,7 +203,11 @@ IsDecimalNotation(const string & s)
     {
         IsAnyThing = TRUE;
 
-        if (!isdigit(CptrChar))
+        //
+        // The cast is needed as passing a negative 'char' to the <ctype.h>
+        // functions is undefined behavior
+        //
+        if (!isdigit((UCHAR)CptrChar))
         {
             return FALSE;
         }
@@ -607,7 +615,12 @@ ValidateIP(const string & ip)
         // verify that string is number or not and the numbers
         // are in the valid range
         //
-        if (!IsNumber(str) || stoi(str) > 255 || stoi(str) < 0)
+        // 'IsNumber' guarantees a non-empty, digits-only string, so 'strtoul'
+        // cannot fail here; it saturates to ULONG_MAX on overflow, which the
+        // range check below rejects. 'std::stoi' is deliberately avoided as it
+        // throws on both non-numeric and out-of-range input
+        //
+        if (!IsNumber(str) || strtoul(str.c_str(), NULL, 10) > 255)
             return FALSE;
     }
 
@@ -699,7 +712,7 @@ SetPrivilege(HANDLE  Token,          // access token handle
 static inline VOID
 ltrim(std::string & s)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](CHAR ch) { return !std::isspace((UCHAR)ch); }));
 }
 
 /**
@@ -710,7 +723,7 @@ ltrim(std::string & s)
 static inline VOID
 rtrim(std::string & s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); })
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](CHAR ch) { return !std::isspace((UCHAR)ch); })
                 .base(),
             s.end());
 }
@@ -860,10 +873,15 @@ ListDirectory(const std::string & Directory, const std::string & Extension)
     if (Find == INVALID_HANDLE_VALUE)
         throw std::runtime_error("invalid handle value! please check your path...");
 
-    while (FindNextFileA(Find, &FindData) != 0)
+    //
+    // 'FindFirstFileA' already returned the first match in 'FindData', so it
+    // has to be consumed before asking for the next one; otherwise the first
+    // file of the directory is silently dropped from the list
+    //
+    do
     {
         DirList.push_back(Directory + "\\" + std::string(FindData.cFileName));
-    }
+    } while (FindNextFileA(Find, &FindData) != 0);
 
     FindClose(Find);
 
@@ -1062,7 +1080,7 @@ CheckAddressCanonicality(UINT64 VAddr, PBOOLEAN IsKernelAddress)
     //
     // Set whether it's a kernel address or not
     //
-    if (MinVirtualAddressHighHalf < Addr)
+    if (MinVirtualAddressHighHalf <= Addr)
     {
         *IsKernelAddress = TRUE;
     }

--- a/hyperdbg/libhyperdbg/code/common/common.cpp
+++ b/hyperdbg/libhyperdbg/code/common/common.cpp
@@ -14,6 +14,8 @@
 #ifdef __linux__
 #    include <sys/stat.h>  // struct stat / stat() for IsFileExistA
 #    include <immintrin.h> // Intel TSX RTM intrinsics (_xbegin/_xend); requires -mrtm
+#    include <dirent.h>    // opendir()/readdir() for ListDirectory
+#    include <fnmatch.h>   // fnmatch() for the wildcard filter of ListDirectory
 #endif
 
 //
@@ -887,13 +889,38 @@ ListDirectory(const std::string & Directory, const std::string & Extension)
 
     return DirList;
 #else
+    DIR *                    DirectoryHandle;
+    struct dirent *          DirectoryEntry;
+    std::vector<std::string> DirList;
+
+    DirectoryHandle = opendir(Directory.c_str());
+
+    if (DirectoryHandle == NULL)
+        throw std::runtime_error("invalid handle value! please check your path...");
+
+    while ((DirectoryEntry = readdir(DirectoryHandle)) != NULL)
+    {
+        //
+        // 'FindFirstFileA' applies the wildcard pattern to the file name, so
+        // the same is done here with 'fnmatch'. No flag is passed, which keeps
+        // a leading '.' unremarkable and lets "." and ".." match a bare "*",
+        // exactly like the Win32 walk does
+        //
+        if (fnmatch(Extension.c_str(), DirectoryEntry->d_name, 0) != 0)
+            continue;
+
+        DirList.push_back(Directory + "/" + std::string(DirectoryEntry->d_name));
+    }
+
+    closedir(DirectoryHandle);
+
     //
-    // TODO(Linux): reimplement with opendir/readdir + fnmatch(Extension) over
-    // Directory. Only caller today is the script-engine test harness (eval.cpp).
+    // 'readdir' hands the entries back in whatever order the file system stores
+    // them, so the list is sorted to keep the result reproducible across runs
     //
-    UNREFERENCED_PARAMETER(Directory);
-    UNREFERENCED_PARAMETER(Extension);
-    return std::vector<std::string>();
+    std::sort(DirList.begin(), DirList.end());
+
+    return DirList;
 #endif
 }
 

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/connect.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/connect.cpp
@@ -70,7 +70,7 @@ ConnectRemoteDebugger(const CHAR * Ip, const CHAR * Port)
 
     if (Port != NULL)
     {
-        if (!IsNumber(Port) || stoi(Port) > 65535 || stoi(Port) < 0)
+        if (!IsNumber(Port) || strtoul(Port, NULL, 10) > 65535)
         {
             return FALSE;
         }
@@ -169,7 +169,7 @@ CommandConnect(vector<CommandToken> CommandTokens, string Command)
 
         if (CommandTokens.size() == 3)
         {
-            if (!IsNumber(Port) || stoi(Port) > 65535 || stoi(Port) < 0)
+            if (!IsNumber(Port) || strtoul(Port.c_str(), NULL, 10) > 65535)
             {
                 ShowMessages("incorrect port\n");
                 return;

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/debug.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/debug.cpp
@@ -309,7 +309,7 @@ CommandDebug(vector<CommandToken> CommandTokens, string Command)
         else if (!IsComPortBaudrateKnown && IsSerial && IsNumber(GetCaseSensitiveStringFromCommandToken(Section)))
         {
             IsComPortBaudrateKnown = TRUE;
-            Baudrate               = stoi(GetCaseSensitiveStringFromCommandToken(Section));
+            Baudrate               = strtoul(GetCaseSensitiveStringFromCommandToken(Section).c_str(), NULL, 10);
 
             //
             // Check if baudrate is valid or not

--- a/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/listen.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/commands/meta-commands/listen.cpp
@@ -103,7 +103,7 @@ CommandListen(vector<CommandToken> CommandTokens, string Command)
         // on a specific port, let's see if the
         // port is valid or not
         //
-        if (!IsNumber(Port) || stoi(Port) > 65535 || stoi(Port) < 0)
+        if (!IsNumber(Port) || strtoul(Port.c_str(), NULL, 10) > 65535)
         {
             ShowMessages("incorrect port\n");
             return;

--- a/hyperdbg/libhyperdbg/code/debugger/driver-loader/install-linux.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/driver-loader/install-linux.cpp
@@ -1,7 +1,7 @@
 /**
  * @file install-linux.cpp
  * @author Max Raulea (max.raulea@hyperdbg.org)
- * @brief Linux stub implementations of the driver-loader (install.cpp)
+ * @brief Linux implementations of the driver-loader (install.cpp)
  * @details The Windows implementation (install.cpp) loads/unloads the HyperDbg
  *          kernel-mode driver (the .sys file that contains the actual debugging
  *          engine) through the Windows Service Control Manager (SCM):
@@ -20,24 +20,20 @@
  *          four SC_HANDLE helpers are guarded out of install.h on Linux and are
  *          never referenced there.
  *
- *          TODO(Linux) to make these real once a Linux kernel component lands:
+ *          SetupPathForFileName is a generic "find a file beside my binary"
+ *          helper rather than a driver-loading one (it is also used for the
+ *          hwdbg test/script files and the PCI ID database), so it is
+ *          implemented for real here: readlink("/proc/self/exe") is the
+ *          GetModuleFileName counterpart, and the rest of the Windows logic
+ *          (strip the program name, append the requested file, optionally check
+ *          that it exists) maps over unchanged.
+ *
+ *          TODO(Linux) to make the rest real once a Linux kernel component lands:
  *          - ManageDriver: load/unload the future HyperDbg Linux kernel module.
  *            The natural backend is insmod/rmmod semantics via the finit_module(2)
  *            / delete_module(2) syscalls (or libkmod), taking the .ko path built
  *            by SetupPathForFileName. DRIVER_FUNC_INSTALL/START -> load,
  *            DRIVER_FUNC_STOP/REMOVE -> unload. Requires CAP_SYS_MODULE (root).
- *          - SetupPathForFileName: build the absolute path of a file that sits
- *            next to the running executable. The Windows version uses
- *            GetModuleFileName + strip-after-last-'\\' + append '\\'+FileName +
- *            optional existence check. The Linux equivalent is:
- *              readlink("/proc/self/exe", ...)  (the kernel-provided symlink to
- *              the current process's own binary, i.e. the GetModuleFileName
- *              counterpart), then strrchr(..., '/') to strip the program name,
- *              append '/' + FileName, and (if CheckFileExists) verify with
- *              access(path, F_OK). Mind BufferLength bounds on every write.
- *            This is a generic "find a file beside my binary" helper (also used
- *            for the hwdbg test/script files, not just the driver), so it is the
- *            one that is actually worth implementing for real later.
  *
  * @version 0.1
  * @date 2026-07-18
@@ -48,6 +44,9 @@
 #include "pch.h"
 
 #ifdef __linux__
+
+#    include <unistd.h> // readlink()/access() for SetupPathForFileName
+#    include <errno.h>  // errno/strerror() for the readlink() failure message
 
 /**
  * @brief Install / start / stop / remove the HyperDbg kernel driver.
@@ -74,14 +73,15 @@ ManageDriver(_In_ LPCTSTR DriverName, _In_ LPCTSTR ServiceName, _In_ UINT16 Func
 /**
  * @brief Build the absolute path of a file located next to the running binary.
  *
- * @param FileName the file to locate (e.g. the driver or a test/script file)
+ * @param FileName the file to locate (e.g. the driver or a test/script file).
+ *        Windows-style '\\' separators are accepted and normalized
  * @param FileLocation out buffer receiving the full path
- * @param BufferLength size of FileLocation in bytes
+ * @param BufferLength size of FileLocation in bytes. The executable's own path
+ *        is read into the same buffer first, so it has to fit as well
  * @param CheckFileExists whether to verify the resulting path exists
  *
- * @return BOOLEAN FALSE — not implemented on Linux yet. The real version should
- *         use readlink("/proc/self/exe") + strip + append + access(); see the
- *         file header TODO(Linux).
+ * @return BOOLEAN whether the path could be built (and, when asked for, whether
+ *         the resulting file exists)
  */
 BOOLEAN
 SetupPathForFileName(const CHAR *                                  FileName,
@@ -89,13 +89,98 @@ SetupPathForFileName(const CHAR *                                  FileName,
                      ULONG                                         BufferLength,
                      BOOLEAN                                       CheckFileExists)
 {
-    UNREFERENCED_PARAMETER(FileName);
-    UNREFERENCED_PARAMETER(FileLocation);
-    UNREFERENCED_PARAMETER(BufferLength);
-    UNREFERENCED_PARAMETER(CheckFileExists);
+    ssize_t PathLength;
+    CHAR *  ProgramName;
+    SIZE_T  DirectoryLength;
+    SIZE_T  FileNameLength;
 
-    ShowMessages("err, SetupPathForFileName is not supported on Linux yet\n");
-    return FALSE;
+    if (FileName == NULL || FileLocation == NULL || BufferLength == 0)
+    {
+        return FALSE;
+    }
+
+    //
+    // "/proc/self/exe" is the kernel-provided symlink to the binary of the
+    // running process, which makes it the counterpart of the
+    // GetModuleFileName(GetModuleHandle(NULL), ...) used on Windows.
+    // readlink() never writes a null terminator, so the last byte of the
+    // buffer is reserved for it
+    //
+    PathLength = readlink("/proc/self/exe", FileLocation, BufferLength - 1);
+
+    if (PathLength < 0)
+    {
+        ShowMessages("err, unable to resolve the path of the current executable (%s)\n",
+                     strerror(errno));
+
+        return FALSE;
+    }
+
+    //
+    // readlink() truncates silently, so a result that fills the buffer means
+    // the path is (possibly) incomplete and would point at the wrong file
+    //
+    if ((ULONG)PathLength >= BufferLength - 1)
+    {
+        ShowMessages("err, the path of the current executable does not fit in the buffer\n");
+
+        return FALSE;
+    }
+
+    FileLocation[PathLength] = '\0';
+
+    //
+    // Remove the program name and keep the directory that contains it; this is
+    // the '/' counterpart of the strrchr(FileLocation, '\\') in install.cpp
+    //
+    ProgramName = strrchr(FileLocation, '/');
+
+    if (ProgramName == NULL)
+    {
+        ShowMessages("err, unable to resolve the directory of the current executable\n");
+
+        return FALSE;
+    }
+
+    DirectoryLength = (SIZE_T)(ProgramName - FileLocation);
+
+    //
+    // The directory, the separator, the file name and the null terminator all
+    // have to fit; this is what the StringCbCat() calls check on Windows
+    //
+    FileNameLength = strlen(FileName);
+
+    if (DirectoryLength + FileNameLength + 2 > BufferLength)
+    {
+        ShowMessages("err, the path of the target file does not fit in the buffer\n");
+
+        return FALSE;
+    }
+
+    FileLocation[DirectoryLength] = '/';
+    memcpy(FileLocation + DirectoryLength + 1, FileName, FileNameLength + 1);
+
+    //
+    // The file names come from shared headers and are spelled the Windows way
+    // (e.g. "constants\\pci.ids"), so the separators of the appended part are
+    // normalized; otherwise the backslashes would end up inside a file name
+    //
+    for (SIZE_T i = DirectoryLength + 1; i <= DirectoryLength + FileNameLength; i++)
+    {
+        if (FileLocation[i] == '\\')
+        {
+            FileLocation[i] = '/';
+        }
+    }
+
+    if (CheckFileExists && access(FileLocation, F_OK) != 0)
+    {
+        ShowMessages("err, target file is not loaded\n");
+
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 #endif // __linux__

--- a/hyperdbg/libhyperdbg/code/debugger/misc/pci-id.cpp
+++ b/hyperdbg/libhyperdbg/code/debugger/misc/pci-id.cpp
@@ -407,15 +407,23 @@ GetVendorById(UINT16 VendorId)
 
     return GetVendorByIdStr(ExecutablePath, ToLower(VendorIdAsStr));
 #else
-    //
-    // TODO(Linux): resolve the PCI ID database next to the executable via
-    // readlink("/proc/self/exe") once the path separator and
-    // PCI_ID_DATABASE_PATH ("constants\\pci.ids") are made portable. Until
-    // then no vendor/device names are available on Linux.
-    //
-    UNREFERENCED_PARAMETER(VendorId);
+    CHAR VendorIdAsStr[5];
+    CHAR DatabasePath[MAX_PATH];
 
-    return NULL;
+    snprintf(VendorIdAsStr, sizeof(VendorIdAsStr), "%04X", VendorId);
+
+    //
+    // The database ships next to the executable, which is what
+    // SetupPathForFileName resolves; it also normalizes the separators of
+    // PCI_ID_DATABASE_PATH ("constants\\pci.ids") on the way. The existence
+    // check is left to GetVendorByIdStr, which reports the missing database
+    //
+    if (!SetupPathForFileName(PCI_ID_DATABASE_PATH, DatabasePath, sizeof(DatabasePath), FALSE))
+    {
+        return NULL;
+    }
+
+    return GetVendorByIdStr(DatabasePath, ToLower(VendorIdAsStr));
 #endif
 }
 

--- a/hyperdbg/linux/PORTING_STATUS.md
+++ b/hyperdbg/linux/PORTING_STATUS.md
@@ -78,12 +78,12 @@ Shared, OS-neutral headers:
 |------|----------|---------------|-------------------|
 | `.../script-engine/symbol-linux.cpp` | `symbol.cpp` (DbgHelp + PDB) | All `Symbol*` functions. Only `SymbolConvertNameOrExprToAddress` does real work: parses a plain hex/decimal literal so numeric addresses work. | Real ELF/DWARF symbol parser (libdw / libelf / libbfd). |
 | `.../user-level/pe-parser-linux.cpp` | `pe-parser.cpp` (Windows PE format) | The 3 public fns: `PeShowSectionInformationAndDump`, `PeIsPE32BitOr64Bit` (→ FALSE), `PeGetSyscallNumber` (→ 0). | Recreate the Windows `IMAGE_*` headers for Linux, then port `pe-parser.cpp`. Only needed for Windows-target debugging on Linux. |
-| `.../driver-loader/install-linux.cpp` | `install.cpp` (SCM driver loader) | The 2 Linux-visible public fns: `ManageDriver` (→ FALSE) and `SetupPathForFileName` (→ FALSE). The 4 `SC_HANDLE` helpers (`InstallDriver`/`RemoveDriver`/`StartDriver`/`StopDriver`) are guarded out of `install.h` on Linux (never referenced there). | `ManageDriver`: load/unload a future HyperDbg Linux kernel module via `finit_module`/`delete_module` (needs CAP_SYS_MODULE). `SetupPathForFileName`: `readlink("/proc/self/exe")` + strip + append + `access()` (generic "find a file beside my binary"; also used by hwdbg). |
+| `.../driver-loader/install-linux.cpp` | `install.cpp` (SCM driver loader) | Only `ManageDriver` (→ FALSE) is still a stub; `SetupPathForFileName` is **implemented** (`readlink("/proc/self/exe")` + strip + append + `access()`). The 4 `SC_HANDLE` helpers (`InstallDriver`/`RemoveDriver`/`StartDriver`/`StopDriver`) are guarded out of `install.h` on Linux (never referenced there). | `ManageDriver`: load/unload a future HyperDbg Linux kernel module via `finit_module`/`delete_module` (needs CAP_SYS_MODULE). |
 | `.../communication/namedpipe-linux.cpp` | `namedpipe.cpp` (Win32 named-pipe IPC) | All 10 public `NamedPipeServer*`/`NamedPipeClient*` fns. `Create*` → `INVALID_HANDLE_VALUE` (print); send/read → 0/FALSE; close → no-op (quiet, unreachable once Create fails). The two internal `*Example()` demos are not in the Linux TU. | Back with a filesystem FIFO (`mkfifo`) or, better for framed bidirectional messages, an `AF_UNIX` socket derived from the `\\.\pipe\NAME` string; overlapped/event I/O collapses to blocking `read`/`write`. |
 
-All four self-guard with `#ifdef __linux__` and print
-`"... is not supported on Linux yet"` at runtime (named-pipe: only in the
-`Create*` entry points, to avoid per-loop spam).
+All four self-guard with `#ifdef __linux__`, and every function still stubbed in
+them prints `"... is not supported on Linux yet"` at runtime (named-pipe: only in
+the `Create*` entry points, to avoid per-loop spam).
 
 ---
 
@@ -186,8 +186,8 @@ equivalent, behavior-preserving.
   - Whole Windows-only bodies guarded `#ifdef _WIN32` with a Linux stub + TODO:
     `SetPrivilege` (token/LUID; no Linux callers → returns FALSE),
     `IsFileExistW` (`_wstat`; wide-char deferred → FALSE),
-    `GetConfigFilePath` (`GetModuleFileNameW`/shlwapi; wide-char deferred → empties path),
-    `ListDirectory` (`FindFirstFileA`; → empty vector, only caller is eval.cpp test harness).
+    `GetConfigFilePath` (`GetModuleFileNameW`/shlwapi; wide-char deferred → empties path).
+  - `ListDirectory` — **implemented** (2026-08-02), see the file-location section below.
   - `CheckAddressValidityUsingTsx` — TSX `_xbegin`/`_xend`/`_XBEGIN_STARTED` kept
     verbatim; they resolve on GCC via `<immintrin.h>` (included under `__linux__`)
     once `-mrtm` is set. Added `target_compile_options(libhyperdbg PRIVATE -mrtm)`
@@ -553,9 +553,14 @@ Windows-path-shaped in two places — the `'\\'` separator and the constant itse
 (`pci-id.h:44`, `"constants\\pci.ids"`) — so wrapping only the calls would leave
 `strrchr` returning NULL, silently overwriting the whole path and resolving
 against the cwd. That is a behaviour change, not a port, so the whole body is
-Windows-only and Linux returns NULL. `GetVendorByIdStr`, `GetDeviceFromVendor`,
+Windows-only and Linux returns NULL.
+**Resolved (2026-08-02)** — the Linux `#else` now calls `SetupPathForFileName`,
+which does the `readlink` walk *and* the separator normalization in one place, so
+neither of the two path-shape problems is left in `pci-id.cpp`. See the
+file-location section below. `GetVendorByIdStr`, `GetDeviceFromVendor`,
 `FreeVendor` and `FreePciIdDatabase` are plain C and compile unchanged.
-Consequence: `!pcitree` / `!pcicam` show no vendor or device names on Linux.
+Consequence: `!pcitree` / `!pcicam` now show vendor and device names on Linux
+too, as long as `constants/pci.ids` is deployed next to the binary.
 
 **Result: the CLI link is down from 23 undefined refs to 9**, and every
 "missing TU" bucket is now closed. What is left is both known and deliberate:
@@ -709,10 +714,9 @@ Grouped by subsystem. These are the shortcuts taken to reach compilation.
   keystone section above.
 
 ### PCI ID database
-- [ ] `pci-id.cpp::GetVendorById` — Linux returns NULL (whole body Windows-only).
-  Needs `readlink("/proc/self/exe")` **plus** a portable path separator and a
-  portable `PCI_ID_DATABASE_PATH` (`pci-id.h:44` is `"constants\\pci.ids"`).
-  Until then `!pcitree` / `!pcicam` print no vendor/device names on Linux.
+- [x] `pci-id.cpp::GetVendorById` — done (2026-08-02). The Linux branch resolves
+  the database through `SetupPathForFileName`, which normalizes the `'\\'` of
+  `PCI_ID_DATABASE_PATH` (`pci-id.h:44`), so the constant itself stays shared.
 
 ### PE parsing
 - [ ] Recreate Windows `IMAGE_*` headers for Linux and port `pe-parser.cpp`
@@ -723,6 +727,63 @@ Grouped by subsystem. These are the shortcuts taken to reach compilation.
 - [ ] `platform-serial.c` Linux branch — implement termios serial I/O (currently stub).
 - [ ] `platform-ioctl.c` Linux branch — needs a Linux kernel module + real ioctl
   (currently stub). This is the local driver interface used across many files.
+
+### File location on disk — DONE (2026-08-02)
+
+Three of the "find a file" stubs are now real. They are grouped here because the
+first one is what unblocks the other two.
+
+**`install-linux.cpp::SetupPathForFileName`** — the generic "find a file beside
+my binary" helper, used for the driver path (`libhyperdbg.cpp`), the hwdbg
+test/script files (`hwdbg-interpreter.cpp`, `hwdbg-scripts.cpp`), the exported
+`hyperdbg_u_setup_path_for_filename` and now the PCI ID database. A 1:1 port of
+the Windows body, call for call: `readlink("/proc/self/exe")` is the
+`GetModuleFileName(GetModuleHandle(NULL), ...)` counterpart, `strrchr(..., '/')`
+replaces `strrchr(..., '\\')`, and `access(path, F_OK)` replaces the
+`CreateFile(..., OPEN_EXISTING)` probe behind `CheckFileExists`.
+
+Two things the Windows version does not do:
+
+- **`BufferLength` is honoured on every write.** `readlink` truncates silently,
+  so a result that fills the buffer is rejected rather than handed back as a
+  valid-looking path to the wrong file, and the directory + `'/'` + name + NUL
+  total is checked before the append. (`install.cpp` gets the second half of
+  this from `StringCbCat`, but not the first: its `GetModuleFileName` truncation
+  is unchecked.)
+- **Windows-style separators in `FileName` are normalized to `'/'`.** The file
+  names come from shared headers and are spelled the Windows way —
+  `HWDBG_TEST_READ_INSTANCE_INFO_PATH` (`HardwareDebugger.h:42`) and
+  `PCI_ID_DATABASE_PATH` (`pci-id.h:44`). Doing it here keeps the constants
+  shared and keeps the `#ifdef` out of every call site. Only the appended part
+  is rewritten, so a `'\\'` inside a real Linux directory name survives.
+
+**`common.cpp::ListDirectory`** — `opendir`/`readdir` with `fnmatch` for the
+wildcard, mirroring how `FindFirstFileA` applies the pattern to the file name.
+No `fnmatch` flag is passed, so a leading `'.'` is unremarkable and `"."`/`".."`
+match a bare `"*"`, as they do in the Win32 walk. A missing directory throws the
+same `std::runtime_error` as the `INVALID_HANDLE_VALUE` branch. One deliberate
+difference: the result is sorted, because `readdir` returns entries in
+file-system order and the caller (eval.cpp's test harness) is easier to compare
+across runs when the order is stable.
+
+**`pci-id.cpp::GetVendorById`** — the Linux `#else` builds the database path with
+`SetupPathForFileName` and calls the same `GetVendorByIdStr` as Windows. This was
+previously left Windows-only because wrapping just the two Win32 calls would have
+left `strrchr` looking for a `'\\'`; the normalization above removes that
+objection. `!pcitree` / `!pcicam` now resolve vendor and device names on Linux
+whenever `constants/pci.ids` is deployed next to the binary.
+
+Verified by extracting `SetupPathForFileName` and the Linux `ListDirectory`
+branch into a standalone harness built with `-fsanitize=address,undefined`: 20
+probes covering the separator normalization, the `CheckFileExists` outcomes, the
+exact-fit and one-byte-short buffer boundaries, a buffer too small for the
+executable path itself, the NULL/zero-length arguments, and the four
+`ListDirectory` cases (filtering, sorting, empty match, missing directory). All
+pass with no sanitizer diagnostics. The three modified files were also compiled
+with the project's own Linux CMake build.
+
+Still open: `GetConfigFilePath` remains stubbed. It is the same walk, but its
+out-parameter is a `PWCHAR`, so it stays behind the wide-char item.
 
 ### Process control — `ud.cpp` DONE (2026-07-18)
 Mechanical wrapper sweep (bucket 1): `DeviceIoControl`×10→`PlatformDeviceIoControl`,
@@ -803,10 +864,11 @@ but out of scope for the port.
 - [ ] `$peb` pseudo-register — returns 0 on Linux (PEB is NT-only).
 - [ ] `DebuggerGetNtoskrnlBase` — returns NULL on Linux (NT system-module enum).
 - [ ] File I/O / user-debugger paths — stubbed (also blocked on wide-char above).
-- [ ] `common.cpp::ListDirectory` — Linux returns empty vector; reimplement with
-  `opendir`/`readdir` + `fnmatch` (only caller today is eval.cpp's test harness).
+- [x] `common.cpp::ListDirectory` — done (2026-08-02) with `opendir`/`readdir` +
+  `fnmatch`.
 - [ ] `common.cpp::GetConfigFilePath` — Linux empties the path; resolve via
-  `readlink("/proc/self/exe")` + append `CONFIG_FILE_NAME` (also blocked on wide-char).
+  `readlink("/proc/self/exe")` + append `CONFIG_FILE_NAME` (still blocked on
+  wide-char — `SetupPathForFileName` is the `CHAR` counterpart and is done).
 - [ ] `common.cpp::SetPrivilege` / `IsFileExistW` — Linux stubs (no callers /
   wide-char deferred respectively).
 - [x] `cpu.cpp:148` & `cpu.cpp:200` — same `CpuIdEx`→`CpuCpuIdEx` typo fix as


### PR DESCRIPTION
This pull request focuses on improving input validation, portability, and correctness in several utility functions across the codebase. The main changes include safer character handling for standard library functions, improved numeric parsing to avoid exceptions, and fixes for logical errors in file and address handling.

**Input validation and parsing improvements:**

* Replaced `std::stoi` with `strtoul` for numeric string parsing in port and IP address validation, ensuring non-exception-based error handling and proper range checks, and removed unnecessary lower-bound checks [[1]](diffhunk://#diff-2f5e923e65637bca4086fdb7dae9c32fbbc3745e5ccce0d11b654f1d862afa49L610-R623) [[2]](diffhunk://#diff-a871c4500049fcb1c467b5c3ee79c3cf589d6b3c087ac89742a0547321ff3f6eL73-R73) [[3]](diffhunk://#diff-a871c4500049fcb1c467b5c3ee79c3cf589d6b3c087ac89742a0547321ff3f6eL172-R172) [[4]](diffhunk://#diff-71198200cc5458235c8bcf78528c5c4b1e0512a820244725b3c2b50da47e95a2L106-R106) [[5]](diffhunk://#diff-61170b4b3cc55545b8c055d372997e17b488e9e9942280e4f03738130bd4a56bL312-R312).
* Fixed `IsNumber` to correctly check for digits by removing square brackets from the argument to `find_first_not_of`.

**Portability and correctness with character handling:**

* Added explicit casts to `UCHAR` before passing characters to `<ctype.h>` functions like `isxdigit`, `isdigit`, and `isspace`, preventing undefined behavior with negative `char` values [[1]](diffhunk://#diff-2f5e923e65637bca4086fdb7dae9c32fbbc3745e5ccce0d11b654f1d862afa49L175-R179) [[2]](diffhunk://#diff-2f5e923e65637bca4086fdb7dae9c32fbbc3745e5ccce0d11b654f1d862afa49L202-R210) [[3]](diffhunk://#diff-2f5e923e65637bca4086fdb7dae9c32fbbc3745e5ccce0d11b654f1d862afa49L702-R715) [[4]](diffhunk://#diff-2f5e923e65637bca4086fdb7dae9c32fbbc3745e5ccce0d11b654f1d862afa49L713-R726).

**Logic and correctness fixes:**

* Corrected file listing logic in `ListDirectory` to ensure the first file found is not skipped by consuming the result of `FindFirstFileA` before entering the loop.
* Fixed address range comparison in `CheckAddressCanonicality` to use `<=` instead of `<`, ensuring addresses at the boundary are correctly classified.# Description

Please include a summary of the change and which issue is fixed. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant, or add anything you think would be helpful.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Please ONLY submit your pull request to the "Dev" branch, pull requests to the "Master" branch are not accepted!**
