### PR TITLE
Preserve the original byte of the first hidden breakpoint on a page

### DIFF
--- a/hyperdbg/hyperhv/code/hooks/ept-hook/EptHook.c
+++ b/hyperdbg/hyperhv/code/hooks/ept-hook/EptHook.c
@@ -262,6 +262,16 @@ EptHookCreateHookPage(_Inout_ VIRTUAL_MACHINE_STATE * VCpu,
     MemoryMapperReadMemorySafe((UINT64)VirtualTarget, &HookedPage->FakePageContents, PAGE_SIZE);
 
     //
+    // Save the original byte of the first breakpoint
+    //
+    // It has to be read after the page contents are copied and before the 0xcc is
+    // written over it. EptHookUnHookSingleAddressHiddenBreakpoint() restores this
+    // entry like any other one, so leaving it at the zero the pool manager hands
+    // out would write a 0x00 over the target instruction instead of restoring it
+    //
+    HookedPage->PreviousBytesOnBreakpointAddresses[0] = *(BYTE *)TargetAddressInFakePageContent;
+
+    //
     // we set the breakpoint on the fake page
     //
     *(BYTE *)TargetAddressInFakePageContent = 0xcc;


### PR DESCRIPTION
EptHookCreateHookPage() records BreakpointAddresses[0] and sets CountOfBreakpoints to 1, but never fills in the matching PreviousBytesOnBreakpointAddresses[0]. The entry is allocated with PlatformMemAllocateZeroedNonPagedPool(), so that slot deterministically holds 0x00.

Every later breakpoint on the same page does save its original byte in EptHookUpdateHookPage(), and EptHookUnHookSingleAddressHiddenBreakpoint() restores all slots the same way. Removing the first breakpoint while a second one is still on the page therefore writes 0x00 into the fake page instead of the instruction byte that was there, corrupting the fake-page instruction stream. The 0x00 can also swallow the remaining 0xcc as a ModRM byte, so the surviving breakpoint stops triggering.

Read the byte after the page contents are copied and before the 0xcc is written over it. This also makes the existing comment in the unhooking path correct, which already assumed the first entry holds a valid previous byte.

Fixes #637

# Description

Please include a summary of the change and which issue is fixed. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant, or add anything you think would be helpful.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Please ONLY submit your pull request to the "Dev" branch, pull requests to the "Master" branch are not accepted!**
