### PR TITLE
Size the PCI CAM config space buffer at its real 256 bytes

### DIFF
--- a/hyperdbg/hyperhv/code/devices/Pci.c
+++ b/hyperdbg/hyperhv/code/devices/Pci.c
@@ -29,7 +29,7 @@ PciReadCam(WORD Bus, WORD Device, WORD Function, BYTE Offset, UINT8 Width)
     //
     // Restrict Offset to CAM address space; restrict BDF to our internal limits
     //
-    if (Offset > CAM_CONFIG_SPACE_LENGTH ||
+    if (Offset >= CAM_CONFIG_SPACE_LENGTH ||
         Bus >= BUS_MAX_NUM ||
         Device >= DEVICE_MAX_NUM ||
         Function >= FUNCTION_MAX_NUM)
@@ -79,7 +79,7 @@ PciWriteCam(WORD Bus, WORD Device, WORD Function, BYTE Offset, UINT8 Width, QWOR
     //
     // Restrict Offset to CAM address space; restrict BDF to our internal limits
     //
-    if (Offset > CAM_CONFIG_SPACE_LENGTH ||
+    if (Offset >= CAM_CONFIG_SPACE_LENGTH ||
         Bus >= BUS_MAX_NUM ||
         Device >= DEVICE_MAX_NUM ||
         Function >= FUNCTION_MAX_NUM)

--- a/hyperdbg/include/SDK/headers/Pcie.h
+++ b/hyperdbg/include/SDK/headers/Pcie.h
@@ -40,7 +40,7 @@
 #define DEVICE_MAX_NUM          32
 #define FUNCTION_MAX_NUM        8
 #define DEV_MAX_NUM             255
-#define CAM_CONFIG_SPACE_LENGTH 255
+#define CAM_CONFIG_SPACE_LENGTH 256
 
 /**
  * @brief PCI Common Header


### PR DESCRIPTION
PCI CAM configuration space is 256 bytes, offsets 0x00 to 0xff, but CAM_CONFIG_SPACE_LENGTH is defined as 255, next to BUS_MAX_NUM and DEV_MAX_NUM which legitimately are 255.

The buffer that holds a captured config space is sized from that constant:

    BYTE ConfigSpaceAdditional[CAM_CONFIG_SPACE_LENGTH - sizeof(PORTABLE_PCI_CONFIG_SPACE_HEADER)];

giving 64 + 191 = 255 contiguous bytes. Every loop over it, however, is written in terms of the real 256-byte size and steps in units that overshoot the constant. ExtensionCommandPcidevinfo() fills the buffer with

    for (UINT16 i = 0; i < CAM_CONFIG_SPACE_LENGTH; i += 4)

which runs i = 0, 4, ... 252 and writes a DWORD each time, so it writes 256 bytes into those 255 - one byte past the end of the config space, into the first byte of MmioBarInfo[0].Is64Bit that follows it in PCI_DEV. The write stays inside the enclosing struct, so this is a correctness bug rather than memory corruption, but the last byte of config space is stored outside the buffer that is meant to hold it. The two raw-dump loops (i += 16) likewise cover 256 bytes and read the last one from beyond the buffer.

Define the constant as the length it is named for. The buffer becomes 64 + 192 = 256 bytes, the fill loop lands exactly on the end, and both dump loops cover exactly 16 rows of 16 bytes. The existing

    static_assert(sizeof(DEBUGGEE_PCIDEVINFO_REQUEST_RESPONSE_PACKET) < PacketChunkSize)

still holds with the one byte the packet grows by.

PciReadCam()/PciWriteCam() compare a byte offset against the same constant, so the bound is switched to >= to keep meaning a valid offset now that the constant is a length rather than the highest offset. Both comparisons are still statically false because Offset is a BYTE; this only stops the check from being wrong if that parameter is ever widened.

# Description

Please include a summary of the change and which issue is fixed. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant, or add anything you think would be helpful.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Please ONLY submit your pull request to the "Dev" branch, pull requests to the "Master" branch are not accepted!**
